### PR TITLE
feat: add v2i command muxer

### DIFF
--- a/v2i_command_muxer/CMakeLists.txt
+++ b/v2i_command_muxer/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright 2023 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.5)
+project(v2i_command_muxer)
+
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+
+### Dependencies
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+# Generate exe file
+ament_auto_add_library(v2i_command_muxer
+  SHARED
+  src/v2i_command_muxer.cpp
+)
+
+rclcpp_components_register_node(v2i_command_muxer
+  PLUGIN "v2i_command_muxer::V2iCommandMuxer"
+  EXECUTABLE v2i_command_muxer_node
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/v2i_command_muxer/config/topic_definition.yaml
+++ b/v2i_command_muxer/config/topic_definition.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 /**:
   ros__parameters:
     input_topics : [

--- a/v2i_command_muxer/config/topic_definition.yaml
+++ b/v2i_command_muxer/config/topic_definition.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    input_topics : [
+      "/cargo_loading/infrastructure_commands",
+      "/v2i_gate/infrastructure_commands"
+    ]
+    output_topic : "/v2i/infrastructure_commands"

--- a/v2i_command_muxer/include/v2i_command_muxer/v2i_command_muxer.hpp
+++ b/v2i_command_muxer/include/v2i_command_muxer/v2i_command_muxer.hpp
@@ -1,0 +1,58 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#ifndef V2I_COMMAND_MUXER__V2I_COMMAND_MUXER_HPP_
+#define V2I_COMMAND_MUXER__V2I_COMMAND_MUXER_HPP_
+
+#include <optional>
+#include "rclcpp/rclcpp.hpp"
+
+// input and output
+#include "v2i_interface_msgs/msg/infrastructure_command_array.hpp"
+
+namespace v2i_command_muxer
+{
+
+using CommandArr = v2i_interface_msgs::msg::InfrastructureCommandArray;
+using Command = v2i_interface_msgs::msg::InfrastructureCommand;
+
+class V2iCommandMuxer : public rclcpp::Node
+{
+public:
+  explicit V2iCommandMuxer(const rclcpp::NodeOptions & options);
+private:
+  // Functions
+  void onCommand(const CommandArr::SharedPtr input,
+    const std::string topic_name);
+  void onTimer();
+
+  CommandArr::SharedPtr muxAllCommandArr() const;
+  void deleteAllCommandArr();
+
+  // Publisher
+  rclcpp::Publisher<CommandArr>::SharedPtr cmdarr_pub_;
+
+  // Subscription
+  std::vector<rclcpp::Subscription<CommandArr>::SharedPtr> cmdarr_sub_;
+
+  // Data storage
+  std::unordered_map<std::string, CommandArr::SharedPtr> cmdarr_data_;
+
+  // Publish timer
+  rclcpp::TimerBase::SharedPtr publish_timer_;
+};
+
+}  // namespace v2i_command_muxer
+
+#endif  // V2I_COMMAND_MUXER__V2I_COMMAND_MUXER_HPP_

--- a/v2i_command_muxer/launch/v2i_command_muxer.launch.xml
+++ b/v2i_command_muxer/launch/v2i_command_muxer.launch.xml
@@ -1,3 +1,15 @@
+<!--
+   Copyright 2023 Tier IV, Inc.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
 <launch>
   <node pkg="v2i_command_muxer" exec="v2i_command_muxer_node" name="v2i_command_muxer" output="screen">
     <param from="$(find-pkg-share v2i_command_muxer)/config/topic_definition.yaml"/>

--- a/v2i_command_muxer/launch/v2i_command_muxer.launch.xml
+++ b/v2i_command_muxer/launch/v2i_command_muxer.launch.xml
@@ -1,0 +1,5 @@
+<launch>
+  <node pkg="v2i_command_muxer" exec="v2i_command_muxer_node" name="v2i_command_muxer" output="screen">
+    <param from="$(find-pkg-share v2i_command_muxer)/config/topic_definition.yaml"/>
+  </node>
+</launch>

--- a/v2i_command_muxer/package.xml
+++ b/v2i_command_muxer/package.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+
+<!--
+   Copyright 2023 Tier IV, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<package format="3">
+  <name>v2i_command_muxer</name>
+  <version>0.0.0</version>
+  <description>The v2i command muxer package</description>
+  <maintainer email="yuma.nihei@tier4.jp">Yuma Nihei</maintainer>
+  <license>Apache License 2.0</license>
+  
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>v2i_interface_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <exec_depend>launch_ros</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/v2i_command_muxer/src/v2i_command_muxer.cpp
+++ b/v2i_command_muxer/src/v2i_command_muxer.cpp
@@ -1,0 +1,108 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#include "v2i_command_muxer/v2i_command_muxer.hpp"
+
+namespace v2i_command_muxer
+{
+
+V2iCommandMuxer::V2iCommandMuxer(
+  const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+: Node("v2i_command_muxer", options)
+{
+  using namespace std::placeholders;
+  // Parameter settings
+  std::vector<std::string> input_topics;
+  std::string output_topic;
+  double rate;
+  
+  declare_parameter("input_topics", std::vector<std::string>());
+  input_topics = get_parameter("input_topics").as_string_array();
+  declare_parameter("output_topic", std::string());
+  output_topic = get_parameter("output_topic").as_string();
+  rate = this->declare_parameter<double>("timer_rate", 10.0);
+
+  // Subscription
+  auto group = this->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto subscriber_option = rclcpp::SubscriptionOptions();
+  subscriber_option.callback_group = group;
+  for (const auto& topic : input_topics) {
+    std::function<void(const CommandArr::SharedPtr)> callback_func
+      = std::bind(&V2iCommandMuxer::onCommand, this, _1, topic);
+    cmdarr_sub_.emplace_back(this->create_subscription<CommandArr>(topic, 1,
+      callback_func, subscriber_option));
+  }
+
+  // Publisher
+  cmdarr_pub_ = this->create_publisher<CommandArr>(output_topic, rclcpp::QoS{1});
+
+  // Timer
+  publish_timer_ = create_timer(this, this->get_clock(),
+    rclcpp::Rate(rate).period(), std::bind(&V2iCommandMuxer::onTimer, this),
+    group);
+}
+
+void V2iCommandMuxer::onCommand(const CommandArr::SharedPtr input,
+  const std::string topic_name)
+{
+  cmdarr_data_[topic_name] = input;
+}
+
+void V2iCommandMuxer::onTimer()
+{
+  const auto cmdarr_ptr = muxAllCommandArr();
+  if (!cmdarr_ptr) {
+    return;
+  }
+  cmdarr_pub_->publish(*cmdarr_ptr);
+  deleteAllCommandArr();
+}
+
+CommandArr::SharedPtr V2iCommandMuxer::muxAllCommandArr() const
+{
+  CommandArr::SharedPtr arr_out(new CommandArr);
+  auto& cmd_out = arr_out->commands;
+  for (const auto& cmdmap : cmdarr_data_) {
+    const auto& arr_in = cmdmap.second;
+    if (!arr_in) {
+      continue;
+    }
+    const auto& cmd_in = arr_in->commands;
+    if (cmd_in.empty()) {
+      continue;
+    }
+    cmd_out.insert(cmd_out.end(), cmd_in.begin(), cmd_in.end());
+    if (rclcpp::Time(arr_out->stamp) < rclcpp::Time(arr_in->stamp)) {
+      arr_out->stamp = arr_in->stamp;
+    }
+  }
+  if (arr_out->commands.empty()) {
+    arr_out.reset();
+  }
+  return arr_out;
+}
+
+void V2iCommandMuxer::deleteAllCommandArr()
+{
+  for (auto& cmdarr : cmdarr_data_) {
+    cmdarr.second.reset();
+  }
+}
+
+}  // namespace v2i_command_muxer
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+RCLCPP_COMPONENTS_REGISTER_NODE(v2i_command_muxer::V2iCommandMuxer)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
複数のv2i_interface_msgs/msg/infrastructure_commands型のメッセージを集約し任意の周期で出力するコンポーネントを追加実装しました。

起動方法：
ros2 launch v2i_command_muxer v2i_command_muxer.launch.xml

## Test performed
/cargo_loading/infrastructure_commands 10Hzと /v2i_gate/infrastructure_commands 10Hzの入力を与えたときに、
/v2i/infrastructure_commands にてそれぞれの出力結果を合成した出力が出ていることを確認しました。

詳細は下記のとおりです。
入力コマンド
```
ros2 topic pub /cargo_loading/infrastructure_commands v2i_interface_msgs/msg/InfrastructureCommandArray "{commands: [ {id: 1, state: 1} ]}" -r 10
ros2 topic pub /v2i_gate/infrastructure_commands v2i_interface_msgs/msg/InfrastructureCommandArray "{ commands: [ {id: 2, state: 3} ] }" -r 10
```
（期待値：ID=1, state=1とID=2, state=3の２つの指示が混合された状態で出力されることが期待値）
出力確認コマンド
```
ros2 topic echo /v2i/infrastructure_commands
```

出力結果
```
stamp:
  sec: 0
  nanosec: 0
commands:
- stamp:
    sec: 0
    nanosec: 0
  id: 2
  state: 3
- stamp:
    sec: 0
    nanosec: 0
  id: 1
  state: 1
---

```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/