### PR TITLE
fix: function fixed bit

### DIFF
--- a/vtl_adapter/src/eve_vtl_attribute.cpp
+++ b/vtl_adapter/src/eve_vtl_attribute.cpp
@@ -32,7 +32,7 @@ std::optional<uint8_t> stringToInt(const std::string& input_str)
 {
   uint8_t output_int;
   try {
-    output_int = std::stoi(input_str);
+    output_int = std::stoi(input_str, nullptr, 0);
   }
   catch (const std::invalid_argument& ex) {
     std::cerr << ex.what() << std::endl;
@@ -40,6 +40,10 @@ std::optional<uint8_t> stringToInt(const std::string& input_str)
   }
   catch (const std::out_of_range& ex) {
     std::cerr << ex.what() << std::endl;
+    return std::nullopt;
+  }
+  catch (...) {
+    std::cerr << "Unknown error" << std::endl;
     return std::nullopt;
   }
   return output_int;
@@ -259,7 +263,7 @@ bool EveVTLAttr::isValidType(const std::string& type) const
 
 bool EveVTLAttr::isValidBit(const uint8_t& bit) const
 {
-  return (bit < MIN_VALUE_BIT || bit > MAX_VALUE_BIT);
+  return (bit >= MIN_VALUE_BIT && bit <= MAX_VALUE_BIT);
 }
 
 bool EveVTLAttr::isValidDirection(const std::string& turn_direction) const


### PR DESCRIPTION
## Description
16進数の文字列を読み込むとfixed_bitでnulloptが返されてしまう不具合を修正しました。
- std::stoiの基数を自動で判別するオプションを有効化し、16進数入力に対応できるようにしました。
　https://cpprefjp.github.io/reference/string/stoi.html
- stoiの例外処理を補強しました。
- bit値の有効値判別の判断条件が誤っていたためこれを修正しました。

## Test performed
vtl_testerの下記のテストケースで動作確認済み。
- vtl_test.response_type.and.01.env
- vtl_test.response_type.match.01.env 
変更前はノードが死亡していたが、変更後はノードが継続的に正常動作することを確認できています。