### PR TITLE
feat: update adapter topic name and connect muxer

### DIFF
--- a/vtl_adapter/CMakeLists.txt
+++ b/vtl_adapter/CMakeLists.txt
@@ -65,5 +65,5 @@ endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE
-  # launch
+  launch
 )

--- a/vtl_adapter/launch/vtl_adapter.launch.xml
+++ b/vtl_adapter/launch/vtl_adapter.launch.xml
@@ -1,0 +1,20 @@
+<!--
+   Copyright 2023 Tier IV, Inc.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<launch>
+  <node pkg="vtl_adapter" exec="vtl_adapter_node" name="vtl_adapter" output="screen">
+    <remap from="~/input/infrastructure_commands"  to="/awapi/tmp/infrastructure_commands"/>
+    <remap from="~/output/infrastructure_commands" to="/v2i_gate/infrastructure_commands"/>
+    <remap from="~/input/infrastructure_states"    to="/v2i/infrastructure_states"/>
+    <remap from="~/output/infrastructure_states"   to="/system/v2x/virtual_traffic_light_states"/>
+  </node>
+</launch>

--- a/vtl_adapter/src/vtl_command_converter.cpp
+++ b/vtl_adapter/src/vtl_command_converter.cpp
@@ -37,7 +37,7 @@ void VtlCommandConverter::init(rclcpp::Node* node)
 
   // Subscription
   command_sub_ = node->create_subscription<MainInputCommandArr>(
-    "/awapi/tmp/infrastructure_commands", 1,
+    "~/input/infrastructure_commands", 1,
     std::bind(&VtlCommandConverter::onCommand, this, _1),
     subscriber_option);
   state_sub_ = node->create_subscription<SubInputState>(
@@ -46,7 +46,7 @@ void VtlCommandConverter::init(rclcpp::Node* node)
     subscriber_option);
   // Publisher
   command_pub_ = node->create_publisher<MainOutputCommandArr>(
-    "/v2i/infrastructure_commands",
+    "~/output/infrastructure_commands",
     rclcpp::QoS{1});
 }
 

--- a/vtl_adapter/src/vtl_state_converter.cpp
+++ b/vtl_adapter/src/vtl_state_converter.cpp
@@ -31,12 +31,12 @@ void VtlStateConverter::init(rclcpp::Node* node)
 
   // Subscription
   state_sub_ = node->create_subscription<InputStateArr>(
-    "/v2i/infrastructure_states", 1,
+    "~/input/infrastructure_states", 1,
     std::bind(&VtlStateConverter::onState, this, _1),
     subscriber_option);
   // Publisher
   state_pub_ = node->create_publisher<OutputStateArr>(
-    "/system/v2x/virtual_traffic_light_states",
+    "~/output/infrastructure_states",
     rclcpp::QoS{1});
 }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
v2i_interfaceとadapterの間にmuxerを挿入するため、adapterのトピック名を変更します。
一部のコンポーネントを一時的に除外したテストも考えられるため、トピック名はlaunchで書き換える前提とし、
ノード実装としては一般名にしてあります。

![image](https://user-images.githubusercontent.com/33311630/221721242-4836aa56-8940-4b2a-b592-98e2681214c6.png)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
vtl_testerのテストサンプル（vtl_test.response_type.and.01.env） + v2i_interface_test.launch.xmlによる設備信号模擬により、
期待した出力結果（approved=trueのvirtual_traffic_light_states出力）が得られることを確認済みです。

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/