### PR TITLE
fix(vtl_adapter): remove type from cutom_tags

### DIFF
--- a/vtl_adapter/include/vtl_adapter/eve_vtl_interface_converter.hpp
+++ b/vtl_adapter/include/vtl_adapter/eve_vtl_interface_converter.hpp
@@ -42,7 +42,7 @@ public:
     const StateMachine::ConstSharedPtr& state) const;
   bool response(const uint8_t& response_bit) const;
 private:
-  bool init(const std::vector<tier4_v2x_msgs::msg::KeyValue>& custom_tags);
+  bool init(const InfrastructureCommand& input_command);
   std::string convertInfraCommand(const uint8_t& input_command) const;
   std::optional<std::string> convertADState(
     const StateMachine::ConstSharedPtr& state) const;

--- a/vtl_adapter/src/eve_vtl_interface_converter.cpp
+++ b/vtl_adapter/src/eve_vtl_interface_converter.cpp
@@ -29,7 +29,7 @@ Class public function
 EveVTLInterfaceConverter::EveVTLInterfaceConverter(const InfrastructureCommand& input_command)
   : command_(input_command)
 {
-  init(input_command.custom_tags);
+  init(input_command);
 }
 
 const std::shared_ptr<EveVTLAttr>& EveVTLInterfaceConverter::vtlAttribute() const
@@ -67,8 +67,15 @@ Class private function
 ***************************************************************
 */
 
-bool EveVTLInterfaceConverter::init(const std::vector<tier4_v2x_msgs::msg::KeyValue>& custom_tags)
+bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
 {
+  const auto type = input_command.type;
+  // type == eva_bacon_system以外のときは初期化失敗
+  if (type != eve_vtl_spec::VALUE_TYPE) {
+    return false;
+  }
+
+  const auto& custom_tags = input_command.custom_tags;
   // custom_tagsが設定されてなければ初期化不要（失敗）
   if (custom_tags.empty()) {
     return false;
@@ -80,13 +87,6 @@ bool EveVTLInterfaceConverter::init(const std::vector<tier4_v2x_msgs::msg::KeyVa
     tags[tag.key] = tag.value;
   }
 
-  // type == eva_bacon_system以外のときは初期化失敗
-  if (tags.find(eve_vtl_spec::KEY_TYPE) == tags.end()) {
-    return false;
-  }
-  else if (tags.at(eve_vtl_spec::KEY_TYPE) != eve_vtl_spec::VALUE_TYPE) {
-    return false;
-  }
   // id, modeが適切に設定されてなければ初期化失敗
   // 成功時はattribute変数にidとmodeを代入する
   std::shared_ptr<EveVTLAttr> attr(new EveVTLAttr);

--- a/vtl_adapter/src/eve_vtl_interface_converter.cpp
+++ b/vtl_adapter/src/eve_vtl_interface_converter.cpp
@@ -90,7 +90,7 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
   // id, modeが適切に設定されてなければ初期化失敗
   // 成功時はattribute変数にidとmodeを代入する
   std::shared_ptr<EveVTLAttr> attr(new EveVTLAttr);
-  attr->setType(tags.at(eve_vtl_spec::KEY_TYPE));
+  attr->setType(type);
   if (tags.find(aw_lanelet_spec::KEY_TURN_DIRECTION) != tags.end()) {
     attr->setTurnDirection(tags.at(aw_lanelet_spec::KEY_TURN_DIRECTION));
   }

--- a/vtl_adapter/src/vtl_state_converter.cpp
+++ b/vtl_adapter/src/vtl_state_converter.cpp
@@ -86,7 +86,7 @@ std::optional<OutputStateArr>
     OutputState output_state;
     output_state.stamp = msg->stamp;
     output_state.type = attr->type();
-    output_state.id = attr->id().value();
+    output_state.id = converter->command().id;
     output_state.approval = converter->response(state.state);
     output_state.is_finalized = true;
     output_state_arr.states.emplace_back(output_state);


### PR DESCRIPTION
- custom_tag内にtype設定は存在しないため、command_arrayよりtype取得した結果をattribute内に取り込むように変更しました。
- laneltとしてのID設定を出力すべき関数で実設備IDを誤って出力している不具合を修正しました。