### PR TITLE
fix(vtl_adapter): add exception handling for initialization failure

### DIFF
--- a/vtl_adapter/src/vtl_command_converter.cpp
+++ b/vtl_adapter/src/vtl_command_converter.cpp
@@ -94,6 +94,9 @@ std::optional<MainOutputCommandArr> VtlCommandConverter::requestCommand(
   const std::shared_ptr<InterfaceConverterMap>& converter_array) const
 {
   MainOutputCommandArr command_array;
+  if (!converter_array) {
+    return std::nullopt;
+  }
   for (const auto& elem : *converter_array) {
     const auto& id = elem.first;
     const auto& converter = elem.second;

--- a/vtl_adapter/src/vtl_command_converter.cpp
+++ b/vtl_adapter/src/vtl_command_converter.cpp
@@ -78,6 +78,9 @@ std::shared_ptr<InterfaceConverterMap> VtlCommandConverter::createConverter(
   std::shared_ptr<InterfaceConverterMap> converter_array(new InterfaceConverterMap());
   for (const auto& orig_elem : original_command->commands) {
     const auto converter(new InterfaceConverter(orig_elem));
+    if (!converter->vtlAttribute()) {
+      continue;
+    }
     const auto id_opt = converter->vtlAttribute()->id();
     if (!id_opt) {
       continue;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
地図情報の初期化失敗時にノードが死んでしまう不具合を修正しました。

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
ID、request_bitほかcustom_tagsの値が不正なときにもノードが死なないことを確認しました。

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/