### PR TITLE
feat: add self approval function

### DIFF
--- a/vtl_adapter/CMakeLists.txt
+++ b/vtl_adapter/CMakeLists.txt
@@ -35,6 +35,7 @@ ament_auto_add_library(vtl_adapter
   src/vtl_adapter.cpp
   src/vtl_state_converter.cpp
   src/vtl_command_converter.cpp
+  src/self_approval_timer.cpp
   src/interface_converter_data_pipeline.cpp
   src/eve_vtl_interface_converter.cpp
   src/eve_vtl_attribute.cpp

--- a/vtl_adapter/include/vtl_adapter/eve_vtl_attribute.hpp
+++ b/vtl_adapter/include/vtl_adapter/eve_vtl_attribute.hpp
@@ -41,11 +41,13 @@ public:
   bool isValidAttr() const;
   const std::optional<uint8_t>& id() const;
   const std::string& type() const;
+  const std::optional<uint8_t>& expectBit() const;
   const std::optional<std::string>& permitState() const;
   std::optional<uint8_t> request(
     const std::string& infra_cmd,
     const std::optional<std::string>& ad_state) const;
   bool response(const uint8_t& response_bit) const;
+  bool isSelfApproval() const;
 
 private:
   bool isValidID(const uint8_t& id) const;

--- a/vtl_adapter/include/vtl_adapter/self_approval_timer.hpp
+++ b/vtl_adapter/include/vtl_adapter/self_approval_timer.hpp
@@ -1,0 +1,59 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#ifndef VTL_ADAPTER__SELF_APPROVAL_TIMER_HPP_
+#define VTL_ADAPTER__SELF_APPROVAL_TIMER_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/logger.hpp"
+
+// input and output
+#include "v2i_interface_msgs/msg/infrastructure_state_array.hpp"
+
+#include "vtl_adapter/interface_converter_data_pipeline.hpp"
+
+namespace self_approval_timer
+{
+
+using InputStateArr = v2i_interface_msgs::msg::InfrastructureStateArray;
+using InputState = v2i_interface_msgs::msg::InfrastructureState;
+using IFConverterDataPipeline =
+  interface_converter_data_pipeline::IFConverterDataPipeline;
+
+class SelfApprovalTimer
+{
+public:
+  void init(rclcpp::Node* node);
+  bool acceptConverterPipeline(
+    std::shared_ptr<IFConverterDataPipeline> converter_pipeline);
+private:
+  // Functions
+  void onTimer();
+  std::optional<InputStateArr> createState();
+
+  // Publisher
+  rclcpp::Publisher<InputStateArr>::SharedPtr state_pub_;
+
+  // Publish timer
+  rclcpp::TimerBase::SharedPtr publish_timer_;
+
+  // Data pipeline
+  std::shared_ptr<IFConverterDataPipeline> converter_pipeline_;
+
+  rclcpp::Node* node_;
+};
+
+}  // namespace self_approval_timer
+
+#endif  // VTL_ADAPTER__SELF_APPROVAL_TIMER_HPP_

--- a/vtl_adapter/include/vtl_adapter/self_approval_timer.hpp
+++ b/vtl_adapter/include/vtl_adapter/self_approval_timer.hpp
@@ -16,7 +16,7 @@
 #define VTL_ADAPTER__SELF_APPROVAL_TIMER_HPP_
 
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp/logger.hpp"
+#include "rclcpp/callback_group.hpp"
 
 // input and output
 #include "v2i_interface_msgs/msg/infrastructure_state_array.hpp"
@@ -52,6 +52,7 @@ private:
   std::shared_ptr<IFConverterDataPipeline> converter_pipeline_;
 
   rclcpp::Node* node_;
+  rclcpp::CallbackGroup::SharedPtr group_;
 };
 
 }  // namespace self_approval_timer

--- a/vtl_adapter/include/vtl_adapter/vtl_adapter.hpp
+++ b/vtl_adapter/include/vtl_adapter/vtl_adapter.hpp
@@ -17,11 +17,13 @@
 
 #include "vtl_adapter/vtl_command_converter.hpp"
 #include "vtl_adapter/vtl_state_converter.hpp"
+#include "vtl_adapter/self_approval_timer.hpp"
 
 namespace vtl_adapter
 {
 using VtlCommandConverter = vtl_command_converter::VtlCommandConverter;
 using VtlStateConverter = vtl_state_converter::VtlStateConverter;
+using SelfApprovalTimer = self_approval_timer::SelfApprovalTimer;
 
 class VtlAdapterNode : public rclcpp::Node
 {
@@ -33,6 +35,9 @@ private:
   
   // state converter
   VtlStateConverter state_converter_;
+
+  // self approval timer
+  SelfApprovalTimer self_approval_timer_;
 };
 
 }  // namespace vtl_adapter

--- a/vtl_adapter/src/eve_vtl_attribute.cpp
+++ b/vtl_adapter/src/eve_vtl_attribute.cpp
@@ -187,6 +187,11 @@ const std::string& EveVTLAttr::type() const
   return type_;
 }
 
+const std::optional<uint8_t>& EveVTLAttr::expectBit() const
+{
+  return expect_bit_;
+}
+
 const std::optional<std::string>& EveVTLAttr::permitState() const
 {
   return permit_state_;
@@ -235,6 +240,14 @@ bool EveVTLAttr::response(const uint8_t& response_bit) const
     (false);
 }
 
+bool EveVTLAttr::isSelfApproval() const
+{
+  if (!isValidAttr()) {
+    return false;
+  }
+  const auto type = response_type_.value();
+  return (type == VALUE_RESPONSE_TYPE_ALWAYS);
+}
 /*
 *************************************************************
   Class private function

--- a/vtl_adapter/src/self_approval_timer.cpp
+++ b/vtl_adapter/src/self_approval_timer.cpp
@@ -28,15 +28,15 @@ void SelfApprovalTimer::init(rclcpp::Node* node)
   rate = node->declare_parameter<double>("timer_rate", 10.0);
 
   using namespace std::placeholders;
-  auto group = node->create_callback_group(
+  group_ = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
   auto subscriber_option = rclcpp::SubscriptionOptions();
-  subscriber_option.callback_group = group;
+  subscriber_option.callback_group = group_;
 
   // Timer
   publish_timer_ = create_timer(node, node->get_clock(),
     rclcpp::Rate(rate).period(), std::bind(&SelfApprovalTimer::onTimer, this),
-    group);
+    group_);
   
   // Publisher
   state_pub_ = node->create_publisher<InputStateArr>(

--- a/vtl_adapter/src/self_approval_timer.cpp
+++ b/vtl_adapter/src/self_approval_timer.cpp
@@ -1,0 +1,107 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#include "vtl_adapter/self_approval_timer.hpp"
+#include "vtl_adapter/interface_converter_data_pipeline.hpp"
+
+namespace self_approval_timer
+{
+
+void SelfApprovalTimer::init(rclcpp::Node* node)
+{
+  if (!node) {
+    return;
+  }
+  node_ = node;
+  double rate;
+  rate = node->declare_parameter<double>("timer_rate", 10.0);
+
+  using namespace std::placeholders;
+  auto group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto subscriber_option = rclcpp::SubscriptionOptions();
+  subscriber_option.callback_group = group;
+
+  // Timer
+  publish_timer_ = create_timer(node, node->get_clock(),
+    rclcpp::Rate(rate).period(), std::bind(&SelfApprovalTimer::onTimer, this),
+    group);
+  
+  // Publisher
+  state_pub_ = node->create_publisher<InputStateArr>(
+    "~/input/infrastructure_states",
+    rclcpp::QoS{1});
+}
+
+bool SelfApprovalTimer::acceptConverterPipeline(
+  std::shared_ptr<IFConverterDataPipeline> converter_pipeline)
+{
+  if (converter_pipeline_) {
+    return false;
+  }
+  converter_pipeline_ = converter_pipeline;
+  return true;
+}
+
+void SelfApprovalTimer::onTimer()
+{
+  if (!converter_pipeline_) {
+    return;
+  }
+  else if (!converter_pipeline_->load()) {
+    return;
+  }
+  const auto self_input_state = createState();
+  if (!self_input_state) {
+    return;
+  }
+  state_pub_->publish(self_input_state.value());
+}
+
+std::optional<InputStateArr> SelfApprovalTimer::createState()
+{
+  const auto converter_map = converter_pipeline_->load();
+  if (!converter_map) {
+    return std::nullopt;
+  }
+  else if (converter_map->empty()) {
+    return std::nullopt;
+  }
+
+  InputStateArr self_input_state_arr;
+  self_input_state_arr.stamp = rclcpp::Clock(RCL_ROS_TIME).now();
+  for (const auto& elem : *converter_map) {
+    const auto& converter = elem.second;
+    const auto& attr = converter->vtlAttribute();
+    if (!attr) {
+      continue;
+    }
+    else if (!attr->isValidAttr()) {
+      continue;
+    }
+    else if (!attr->isSelfApproval()) {
+      continue;
+    }
+    InputState self_input_state;
+    self_input_state.stamp = self_input_state_arr.stamp;
+    self_input_state.id = attr->id().value();
+    self_input_state.state = attr->expectBit().value();
+    self_input_state_arr.states.emplace_back(self_input_state);
+  }
+  if (self_input_state_arr.states.empty()) {
+    return std::nullopt;
+  }
+  return self_input_state_arr;
+}
+}  // namespace self_approval_timer

--- a/vtl_adapter/src/vtl_adapter.cpp
+++ b/vtl_adapter/src/vtl_adapter.cpp
@@ -23,7 +23,10 @@ VtlAdapterNode::VtlAdapterNode(
 {
   state_converter_.init(static_cast<rclcpp::Node*>(this));
   command_converter_.init(static_cast<rclcpp::Node*>(this));
+  self_approval_timer_.init(static_cast<rclcpp::Node*>(this));
   state_converter_.acceptConverterPipeline(
+    command_converter_.converterPipeline());
+  self_approval_timer_.acceptConverterPipeline(
     command_converter_.converterPipeline());
 }
 


### PR DESCRIPTION
## Description
下記の挙動を満足できるように修正します。
- request_type==ALWAYSのcommandが与えられた場合には、該当IDに対して（設備応答がなくても）approve出力を出し続けること
- request_type!=ALWAYSのcommandが与えられた場合には、該当IDに対して設備応答がなければapprove出力を返さないこと

現実装では、設備状態に対してevent駆動で動作するようになっており、自己承認の機構が存在していないため前者を満足できていません。本PRとしては、下記のように自己承認の機構を実現するクラスを定義し、追加実装します。
![image](https://user-images.githubusercontent.com/33311630/222631801-3af04781-b8ab-403b-a513-22d4c1a3e4c5.png)

## Test performed
下記について机上確認が完了しています。
- request_type==ALWAYSのcommandが与えられた場合には、該当IDに対して（設備応答がなくても）approve出力を出し続けること
  - 手順：
    - terminal_1 (for test target)
    ```
    ros2 launch vtl_adapter vtl_adapter.launch.xml
    ```
    - terminal_2 (for result monitoring)
    ```
    ros2 topic echo /system/v2x/virtual_traffic_light_states
    ```
    - terminal_3 (for command dummy)
    ```
    cd `ros2 pkg prefix v2i_tester`/lib/v2i_tester
    source vtl_test.clear.env
    source vtl_test.permit_state.01.env
    source test_vtl_command.bash
    ```
  - 結果：
    - ros2 topic echoより下記のapprove出力が出続けることを確認できました。⇒OK判断です。
    ```
    stamp:
      sec: 1677764833
      nanosec: 67021035
    states:
    - stamp:
        sec: 1677764833
        nanosec: 67021035
      type: eva_beacon_system
      id: '3000'
      approval: true
      is_finalized: true
    ```
- request_type!=ALWAYSのcommandが与えられた場合には、該当IDに対して設備応答がなければapprove出力を返さないこと
  - 手順：（request_type==ANDが与えられた場合）
    - terminal_1 (for test target)
    ```
    ros2 launch vtl_adapter vtl_adapter.launch.xml
    ```
    - terminal_2 (for result monitoring)
    ```
    ros2 topic echo /system/v2x/virtual_traffic_light_states
    ```
    - terminal_3 (for command dummy)
    ```
    cd `ros2 pkg prefix v2i_tester`/lib/v2i_tester
    source vtl_test.clear.env
    source vtl_test.response_type.and.01.env
    source test_vtl_command.bash
    ```
  - 結果：
    - ros2 topic echoより全く出力がないことを確認しました。⇒OK判断です。
  - 補足：
    - v2i_interface, v2i_command_muxerとも立ち上げた状態でv2i_interface_testより0x80指示を送信した場合にはAND条件が満たされapprove出力が出ることを再度確認できています。（リグレッション確認済み）