### PR TITLE
feat(vtl_adapter): add timestamp to output command_array

### DIFF
--- a/vtl_adapter/src/vtl_command_converter.cpp
+++ b/vtl_adapter/src/vtl_command_converter.cpp
@@ -128,6 +128,7 @@ std::optional<MainOutputCommandArr> VtlCommandConverter::requestCommand(
   if (command_array.commands.empty()) {
     return std::nullopt;
   }
+  command_array.stamp =  rclcpp::Clock(RCL_ROS_TIME).now();
   return command_array;
 }
 


### PR DESCRIPTION
## Description
vtl_adapterの制御出力としての `/v2i_gate/infrastructure_commands` よりタイムスタンプの埋め込みが漏れていたため追加します。

## Test performed
修正後について、現在時刻のタイムスタンプの埋め込みが正常にできていることを確認済みです。
```
ros2 topic echo /v2i_gate/infrastructure_commands

---
stamp:
  sec: 1678328558
  nanosec: 578996054
commands:
- stamp:
    sec: 1678328553
    nanosec: 678525815
  id: 8
  state: 14
---
```