### PR TITLE
fix: pysimplegui window add finalize and layout

### DIFF
--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -212,8 +212,7 @@ class V2iInterfaceTest(Node):
             [sg.Output(size=(680, 100))],
         ]
 
-        window = sg.Window(
-            title='dummy_infrastructure', size=(700, 700)).Layout(layout)
+        window = sg.Window(title='dummy_infrastructure',layout=layout,size=(700, 700),finalize=True)
         self.run()
 
     def __del__(self):


### PR DESCRIPTION
Description
When "v2i_interface_test.py" execute ,"Unable to complete operation on element with key 0" alert.

Tests performed
When "v2i_interface_test.py" execute, no alert.