### PR TITLE
feat(vtl_adapter): add error messages

### DIFF
--- a/vtl_adapter/include/vtl_adapter/eve_vtl_interface_converter.hpp
+++ b/vtl_adapter/include/vtl_adapter/eve_vtl_interface_converter.hpp
@@ -34,7 +34,8 @@ using StateMachine = autoware_state_machine_msgs::msg::StateMachine;
 class EveVTLInterfaceConverter
 {
 public:
-  explicit EveVTLInterfaceConverter(const InfrastructureCommand& input_command);
+  EveVTLInterfaceConverter(
+    const InfrastructureCommand& input_command, rclcpp::Node* node);
 
   const std::shared_ptr<EveVTLAttr>& vtlAttribute() const;
   const InfrastructureCommand& command() const;
@@ -49,6 +50,7 @@ private:
 
   InfrastructureCommand command_;
   std::shared_ptr<EveVTLAttr> vtl_attr_;
+  rclcpp::Node* node_;
 };
 
 }  // namespace eve_vtl_interface_converter

--- a/vtl_adapter/include/vtl_adapter/vtl_command_converter.hpp
+++ b/vtl_adapter/include/vtl_adapter/vtl_command_converter.hpp
@@ -53,6 +53,7 @@ public:
   void init(rclcpp::Node* node);
   std::shared_ptr<IFConverterDataPipeline> converterPipeline();
 private:
+  // Node
   rclcpp::Node* node_;
 
   // Publisher

--- a/vtl_adapter/include/vtl_adapter/vtl_state_converter.hpp
+++ b/vtl_adapter/include/vtl_adapter/vtl_state_converter.hpp
@@ -42,6 +42,9 @@ public:
   bool acceptConverterPipeline(
     std::shared_ptr<IFConverterDataPipeline> converter_pipeline);
 private:
+  // Node
+  rclcpp::Node* node_;
+
   // Publisher
   rclcpp::Publisher<OutputStateArr>::SharedPtr state_pub_;
 

--- a/vtl_adapter/src/eve_vtl_interface_converter.cpp
+++ b/vtl_adapter/src/eve_vtl_interface_converter.cpp
@@ -20,14 +20,17 @@
 namespace eve_vtl_interface_converter
 {
 
+constexpr static unsigned int ERROR_THROTTLE_MSEC = 1000;
+
 /*
 ***************************************************************
 Class public function
 ***************************************************************
 */
 
-EveVTLInterfaceConverter::EveVTLInterfaceConverter(const InfrastructureCommand& input_command)
-  : command_(input_command)
+EveVTLInterfaceConverter::EveVTLInterfaceConverter(
+  const InfrastructureCommand& input_command, rclcpp::Node* node)
+  : command_(input_command), node_(node)
 {
   init(input_command);
 }
@@ -46,6 +49,9 @@ std::optional<uint8_t> EveVTLInterfaceConverter::request(
     const StateMachine::ConstSharedPtr& state) const
 {
   if (!vtl_attr_) {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: vtl_attr_ is not initialized", __func__);
     return std::nullopt;
   }
   const auto command_str = convertInfraCommand(command_.state);
@@ -56,6 +62,9 @@ std::optional<uint8_t> EveVTLInterfaceConverter::request(
 bool EveVTLInterfaceConverter::response(const uint8_t& response_bit) const
 {
   if (!vtl_attr_) {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: vtl_attr_ is not initialized", __func__);
     return false;
   }
   return vtl_attr_->response(response_bit);
@@ -72,12 +81,18 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
   const auto type = input_command.type;
   // type == eva_bacon_system以外のときは初期化失敗
   if (type != eve_vtl_spec::VALUE_TYPE) {
+    RCLCPP_DEBUG(
+      node_->get_logger(), "EveVTLInterfaceConverter::%s: type is not %s",
+      __func__, eve_vtl_spec::VALUE_TYPE.c_str());
     return false;
   }
 
   const auto& custom_tags = input_command.custom_tags;
   // custom_tagsが設定されてなければ初期化不要（失敗）
   if (custom_tags.empty()) {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: custom_tags is empty", __func__);
     return false;
   }
 
@@ -92,33 +107,86 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
   std::shared_ptr<EveVTLAttr> attr(new EveVTLAttr);
   attr->setType(type);
   if (tags.find(aw_lanelet_spec::KEY_TURN_DIRECTION) != tags.end()) {
-    attr->setTurnDirection(tags.at(aw_lanelet_spec::KEY_TURN_DIRECTION));
+    const bool ret =
+      attr->setTurnDirection(tags.at(aw_lanelet_spec::KEY_TURN_DIRECTION));
+    if (!ret) {
+      RCLCPP_WARN_THROTTLE(
+        node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+        "EveVTLInterfaceConverter::%s: turn_direction is invalid", __func__);
+    }
   }
   if (tags.find(eve_vtl_spec::KEY_MODE) != tags.end()) {
-    attr->setMode(tags.at(eve_vtl_spec::KEY_MODE));
+    const bool ret =
+      attr->setMode(tags.at(eve_vtl_spec::KEY_MODE));
+    if (!ret) {
+      RCLCPP_WARN_THROTTLE(
+        node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+        "EveVTLInterfaceConverter::%s: mode is invalid", __func__);
+    }
   }
   if (tags.find(eve_vtl_spec::KEY_ID) != tags.end()) {
-    attr->setID(tags.at(eve_vtl_spec::KEY_ID));
+    const bool ret =
+      attr->setID(tags.at(eve_vtl_spec::KEY_ID));
+    if (!ret) {
+      RCLCPP_WARN_THROTTLE(
+        node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+        "EveVTLInterfaceConverter::%s: id is invalid: %s",
+        __func__, tags.at(eve_vtl_spec::KEY_ID).c_str());
+    }
   }
   if (tags.find(eve_vtl_spec::KEY_RESPONSE_TYPE) != tags.end()) {
-    attr->setResponseType(tags.at(eve_vtl_spec::KEY_RESPONSE_TYPE));
+    const bool ret =
+      attr->setResponseType(tags.at(eve_vtl_spec::KEY_RESPONSE_TYPE));
+    if (!ret) {
+      RCLCPP_WARN_THROTTLE(
+        node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+        "EveVTLInterfaceConverter::%s: response_type is invalid", __func__);
+    }
   }
   if (tags.find(eve_vtl_spec::KEY_REQUEST_BIT) != tags.end()) {
-    attr->setRequestBit(tags.at(eve_vtl_spec::KEY_REQUEST_BIT));
+    const bool ret =
+      attr->setRequestBit(tags.at(eve_vtl_spec::KEY_REQUEST_BIT));
+    if (!ret) {
+      RCLCPP_WARN_THROTTLE(
+        node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+        "EveVTLInterfaceConverter::%s: request_bit is invalid", __func__);
+    }
   }
   if (tags.find(eve_vtl_spec::KEY_EXPECT_BIT) != tags.end()) {
-    attr->setExpectBit(tags.at(eve_vtl_spec::KEY_EXPECT_BIT));
+    const bool ret =
+      attr->setExpectBit(tags.at(eve_vtl_spec::KEY_EXPECT_BIT));
+    if (!ret) {
+      RCLCPP_WARN_THROTTLE(
+        node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+        "EveVTLInterfaceConverter::%s: expect_bit is invalid", __func__);
+    }
   }
   if (tags.find(eve_vtl_spec::KEY_PERMIT_STATE) != tags.end()) {
-    attr->setPermitState(tags.at(eve_vtl_spec::KEY_PERMIT_STATE));
+    const bool ret =
+      attr->setPermitState(tags.at(eve_vtl_spec::KEY_PERMIT_STATE));
+    if (!ret) {
+      RCLCPP_WARN_THROTTLE(
+        node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+        "EveVTLInterfaceConverter::%s: permit_state is invalid", __func__);
+    }
   }
   if (tags.find(eve_vtl_spec::KEY_SECTION) != tags.end()) {
-    attr->setSection(tags.at(eve_vtl_spec::KEY_SECTION));
+    const bool ret =
+      attr->setSection(tags.at(eve_vtl_spec::KEY_SECTION));
+    if (!ret) {
+      RCLCPP_WARN_THROTTLE(
+        node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+        "EveVTLInterfaceConverter::%s: section is invalid", __func__);
+    }
   }
   if (attr->isValidAttr()) {
     vtl_attr_ = attr;
     return true;
   }
+  RCLCPP_WARN_STREAM_THROTTLE(
+    node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+    "EveVTLInterfaceConverter::" << __func__ <<
+    ": attribute is invalid: " << rosidl_generator_traits::to_yaml(input_command));
   return false;
 }
 
@@ -132,22 +200,31 @@ std::optional<std::string>
   EveVTLInterfaceConverter::convertADState(const StateMachine::ConstSharedPtr& state) const
 {
   if (!vtl_attr_) {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: vtl_attr_ is null", __func__);
     return std::nullopt;
   }
   const auto permit_state_opt = vtl_attr_->permitState();
   if (!permit_state_opt) {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: permit_state is null", __func__);
     return eve_vtl_spec::VALUE_PERMIT_STATE_NULL;
   }
   const auto permit_state = permit_state_opt.value();
 
   if (!state) {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: state is null", __func__);
     return std::nullopt;
   }
   const auto& ctl_state = state->control_layer_state;
   const auto& srv_state = state->service_layer_state;
   bool is_valid_state = false;
   if (permit_state == eve_vtl_spec::VALUE_PERMIT_STATE_MANUAL) {
-      is_valid_state = (ctl_state == StateMachine::MANUAL);
+    is_valid_state = (ctl_state == StateMachine::MANUAL);
   }
   else if (permit_state == eve_vtl_spec::VALUE_PERMIT_STATE_EMERGENCY) {
     is_valid_state = (srv_state == StateMachine::STATE_EMERGENCY_STOP);
@@ -165,6 +242,15 @@ std::optional<std::string>
   }
   else if (permit_state == eve_vtl_spec::VALUE_PERMIT_STATE_NULL) {
     is_valid_state = true;
+  }
+
+  if (!is_valid_state) {
+    RCLCPP_WARN_STREAM_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::" << __func__ <<
+      ": state is invalid: " <<
+      "control_layer_state=" << ctl_state <<
+      ", service_layer_state=" << srv_state);
   }
   return (is_valid_state) ? permit_state_opt : std::nullopt;
 }

--- a/vtl_adapter/src/eve_vtl_interface_converter.cpp
+++ b/vtl_adapter/src/eve_vtl_interface_converter.cpp
@@ -82,8 +82,8 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
   // type == eva_bacon_system以外のときは初期化失敗
   if (type != eve_vtl_spec::VALUE_TYPE) {
     RCLCPP_DEBUG(
-      node_->get_logger(), "EveVTLInterfaceConverter::%s: type is not %s",
-      __func__, eve_vtl_spec::VALUE_TYPE.c_str());
+      node_->get_logger(), "EveVTLInterfaceConverter::%s: type is invalid: %s",
+      __func__, type.c_str());
     return false;
   }
 
@@ -106,24 +106,39 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
   // 成功時はattribute変数にidとmodeを代入する
   std::shared_ptr<EveVTLAttr> attr(new EveVTLAttr);
   attr->setType(type);
+
   if (tags.find(aw_lanelet_spec::KEY_TURN_DIRECTION) != tags.end()) {
     const bool ret =
       attr->setTurnDirection(tags.at(aw_lanelet_spec::KEY_TURN_DIRECTION));
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: turn_direction is invalid", __func__);
+        "EveVTLInterfaceConverter::%s: turn_direction is invalid: %s",
+        __func__, tags.at(aw_lanelet_spec::KEY_TURN_DIRECTION).c_str());
     }
   }
+  else {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: turn_direction is not set", __func__);
+  }
+
   if (tags.find(eve_vtl_spec::KEY_MODE) != tags.end()) {
     const bool ret =
       attr->setMode(tags.at(eve_vtl_spec::KEY_MODE));
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: mode is invalid", __func__);
+        "EveVTLInterfaceConverter::%s: mode is invalid: %s",
+        __func__, tags.at(eve_vtl_spec::KEY_MODE).c_str());
     }
   }
+  else {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: mode is not set", __func__);
+  }
+
   if (tags.find(eve_vtl_spec::KEY_ID) != tags.end()) {
     const bool ret =
       attr->setID(tags.at(eve_vtl_spec::KEY_ID));
@@ -134,59 +149,97 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
         __func__, tags.at(eve_vtl_spec::KEY_ID).c_str());
     }
   }
+  else {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: id is not set", __func__);
+  }
+
   if (tags.find(eve_vtl_spec::KEY_RESPONSE_TYPE) != tags.end()) {
     const bool ret =
       attr->setResponseType(tags.at(eve_vtl_spec::KEY_RESPONSE_TYPE));
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: response_type is invalid", __func__);
+        "EveVTLInterfaceConverter::%s: response_type is invalid: %s",
+        __func__, tags.at(eve_vtl_spec::KEY_RESPONSE_TYPE).c_str());
     }
   }
+  else {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: response_type is not set", __func__);
+  }
+
   if (tags.find(eve_vtl_spec::KEY_REQUEST_BIT) != tags.end()) {
     const bool ret =
       attr->setRequestBit(tags.at(eve_vtl_spec::KEY_REQUEST_BIT));
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: request_bit is invalid", __func__);
+        "EveVTLInterfaceConverter::%s: request_bit is invalid: %s",
+        __func__, tags.at(eve_vtl_spec::KEY_REQUEST_BIT).c_str());
     }
   }
+  else {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: request_bit is not set", __func__);
+  }
+
   if (tags.find(eve_vtl_spec::KEY_EXPECT_BIT) != tags.end()) {
     const bool ret =
       attr->setExpectBit(tags.at(eve_vtl_spec::KEY_EXPECT_BIT));
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: expect_bit is invalid", __func__);
+        "EveVTLInterfaceConverter::%s: expect_bit is invalid: %s",
+        __func__, tags.at(eve_vtl_spec::KEY_EXPECT_BIT).c_str());
     }
   }
+  else {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+      "EveVTLInterfaceConverter::%s: expect_bit is not set", __func__);
+  }
+
   if (tags.find(eve_vtl_spec::KEY_PERMIT_STATE) != tags.end()) {
     const bool ret =
       attr->setPermitState(tags.at(eve_vtl_spec::KEY_PERMIT_STATE));
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: permit_state is invalid", __func__);
+        "EveVTLInterfaceConverter::%s: permit_state is invalid: %s",
+        __func__, tags.at(eve_vtl_spec::KEY_PERMIT_STATE).c_str());
     }
   }
+  else {
+    RCLCPP_DEBUG(node_->get_logger(),
+      "EveVTLInterfaceConverter::%s: permit_state is not set", __func__);
+  }
+
   if (tags.find(eve_vtl_spec::KEY_SECTION) != tags.end()) {
     const bool ret =
       attr->setSection(tags.at(eve_vtl_spec::KEY_SECTION));
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: section is invalid", __func__);
+        "EveVTLInterfaceConverter::%s: section is invalid: %s",
+        __func__, tags.at(eve_vtl_spec::KEY_SECTION).c_str());
     }
   }
+  else {
+    RCLCPP_DEBUG(node_->get_logger(),
+      "EveVTLInterfaceConverter::%s: section is not set", __func__);
+  }
+
   if (attr->isValidAttr()) {
     vtl_attr_ = attr;
     return true;
   }
-  RCLCPP_WARN_STREAM_THROTTLE(
+  RCLCPP_WARN_THROTTLE(
     node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-    "EveVTLInterfaceConverter::" << __func__ <<
-    ": attribute is invalid: " << rosidl_generator_traits::to_yaml(input_command));
+    "EveVTLInterfaceConverter::%s: attribute is invalid", __func__);
   return false;
 }
 

--- a/vtl_adapter/src/eve_vtl_interface_converter.cpp
+++ b/vtl_adapter/src/eve_vtl_interface_converter.cpp
@@ -113,7 +113,7 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: turn_direction is invalid: %s",
+        "EveVTLInterfaceConverter::%s: setTurnDirection calculation failed: input=%s",
         __func__, tags.at(aw_lanelet_spec::KEY_TURN_DIRECTION).c_str());
     }
   }
@@ -129,7 +129,7 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: mode is invalid: %s",
+        "EveVTLInterfaceConverter::%s: setMode calculation failed: input=%s",
         __func__, tags.at(eve_vtl_spec::KEY_MODE).c_str());
     }
   }
@@ -145,7 +145,7 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: id is invalid: %s",
+        "EveVTLInterfaceConverter::%s: setID calculation failed: input=%s",
         __func__, tags.at(eve_vtl_spec::KEY_ID).c_str());
     }
   }
@@ -161,7 +161,7 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: response_type is invalid: %s",
+        "EveVTLInterfaceConverter::%s: setResponseType calculation failed: input=%s",
         __func__, tags.at(eve_vtl_spec::KEY_RESPONSE_TYPE).c_str());
     }
   }
@@ -177,7 +177,7 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: request_bit is invalid: %s",
+        "EveVTLInterfaceConverter::%s: setRequestBit calculation failed: input=%s",
         __func__, tags.at(eve_vtl_spec::KEY_REQUEST_BIT).c_str());
     }
   }
@@ -193,7 +193,7 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: expect_bit is invalid: %s",
+        "EveVTLInterfaceConverter::%s: setExpectBit calculation failed: input=%s",
         __func__, tags.at(eve_vtl_spec::KEY_EXPECT_BIT).c_str());
     }
   }
@@ -209,7 +209,7 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: permit_state is invalid: %s",
+        "EveVTLInterfaceConverter::%s: setPermitState calculation failed: input=%s",
         __func__, tags.at(eve_vtl_spec::KEY_PERMIT_STATE).c_str());
     }
   }
@@ -224,7 +224,7 @@ bool EveVTLInterfaceConverter::init(const InfrastructureCommand& input_command)
     if (!ret) {
       RCLCPP_WARN_THROTTLE(
         node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-        "EveVTLInterfaceConverter::%s: section is invalid: %s",
+        "EveVTLInterfaceConverter::%s: setSection calculation failed: input=%s",
         __func__, tags.at(eve_vtl_spec::KEY_SECTION).c_str());
     }
   }


### PR DESCRIPTION
## Description
例外発生時に解析可能となるように、エラーメッセージの出力を追加するために下記を変更した。
- RCLCPP_WARN, INFO, DEBUG出力の追加
- RCLCPP_WARN, INFO, DEBUG出力を利用するために必要なrclcpp::Nodeの定義およびコンストラクタ引数の変更

変更において考慮すべき点として下記を満足する必要がある。
1. 通常使用時に余計なWARN / ERROR出力がないこと
2. 異常時に解析できる出力が出ること

特に異常なcustom_tagsが設定された場合については、WARNで出力するように設定している。
一方で通常の使いかたでも異常時でも通りうる条件についてはDEBUG出力に寄せ、解析時に必要があればDEBUG出力を見られるようにしている。

## Test performed
1. 通常使用時に余計なWARN / ERROR出力がないこと
=>下記の最小出力のみとなることを確認済みである。
```
ros2 launch vtl_adapter vtl_adapter.launch.xml 
[INFO] [launch]: All log files can be found below /home/autoware/.ros/log/2023-03-09-22-32-43-235070-npc2001001-3551345
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [vtl_adapter_node-1]: process started with pid [3551351]
[vtl_adapter_node-1] [INFO 1678368763.457382010] [vtl_adapter] init(): VtlStateConverter: initialized.
[vtl_adapter_node-1] [INFO 1678368763.458181847] [vtl_adapter] init(): VtlCommandConverter: initialized.
[vtl_adapter_node-1] [INFO 1678368763.458361737] [vtl_adapter] init(): SelfApprovalTimer: initialized.
[vtl_adapter_node-1] [INFO 1678368763.458380426] [vtl_adapter] acceptConverterPipeline(): VtlStateConverter: converter pipeline is accepted.
[vtl_adapter_node-1] [INFO 1678368763.458389538] [vtl_adapter] acceptConverterPipeline(): SelfApprovalTimer: converter pipeline is accepted.
^C[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[vtl_adapter_node-1] [INFO 1678368920.204790169] [rclcpp] signal_handler(): signal_handler(signal_value=2)
[INFO] [vtl_adapter_node-1]: process has finished cleanly [pid 3551351]
```
2. 異常時に解析できる出力が出ること
下記について挙動を確認済み。
<details><summary>vtl_test.mode.invalid.01.env</summary>
modeが無効値の時

```
[vtl_adapter_node-1] [WARN 1678431930.015433148] [vtl_adapter] init(): EveVTLInterfaceConverter::init: setMode calculation failed: input=INVALID
[vtl_adapter_node-1] [WARN 1678431930.015704181] [vtl_adapter] init(): EveVTLInterfaceConverter::init: setRequestBit calculation failed: input=0x01
[vtl_adapter_node-1] [WARN 1678431930.015797865] [vtl_adapter] init(): EveVTLInterfaceConverter::init: setExpectBit calculation failed: input=0x01
[vtl_adapter_node-1] [WARN 1678431930.015907097] [vtl_adapter] init(): EveVTLInterfaceConverter::init: attribute is invalid
```

</details>
<details><summary>vtl_test.mode.turn_dir.not_set.01.env</summary>
turn_directionが設定されていない時

```
[vtl_adapter_node-1] [WARN 1678428004.699368994] [vtl_adapter] init(): EveVTLInterfaceConverter::init: turn_direction is not set
[vtl_adapter_node-1] [WARN 1678428004.699460078] [vtl_adapter] init(): EveVTLInterfaceConverter::init: attribute is invalid
```

</details>
<details><summary>vtl_test.response_type.not_set.01.env</summary>
response_typeが設定されていない時

```
[vtl_adapter_node-1] [WARN 1678427701.827704251] [vtl_adapter] init(): EveVTLInterfaceConverter::init: response_type is not set
[vtl_adapter_node-1] [WARN 1678427701.827869056] [vtl_adapter] init(): EveVTLInterfaceConverter::init: attribute is invalid

```

</details>