### PR TITLE
feat(v2i_interface): respawn from udp disconnection

### DIFF
--- a/v2i_interface/launch/v2i_interface.launch.xml
+++ b/v2i_interface/launch/v2i_interface.launch.xml
@@ -24,7 +24,7 @@
 
   <group>
     <push-ros-namespace namespace="v2i_interface"/>
-    <node pkg="v2i_interface" exec="v2i_interface.py" name="v2i_interface" output="screen">
+    <node pkg="v2i_interface" exec="v2i_interface.py" name="v2i_interface" output="screen" respawn="true" respawn_delay="1.0">
       <param from="$(var config_dir)/$(var operation_mode)/v2i_interface.param.yaml" />
       <remap from="~/input/command_array" to="$(var input/command_array)"/>
       <remap from="~/output/state_array" to="$(var output/state_array)"/>

--- a/v2i_interface/launch/v2i_interface.launch.xml
+++ b/v2i_interface/launch/v2i_interface.launch.xml
@@ -24,7 +24,7 @@
 
   <group>
     <push-ros-namespace namespace="v2i_interface"/>
-    <node pkg="v2i_interface" exec="v2i_interface.py" name="v2i_interface" output="screen" respawn="true" respawn_delay="1.0">
+    <node pkg="v2i_interface" exec="v2i_interface.py" name="v2i_interface" output="screen" respawn="true" respawn_delay="3.0">
       <param from="$(var config_dir)/$(var operation_mode)/v2i_interface.param.yaml" />
       <remap from="~/input/command_array" to="$(var input/command_array)"/>
       <remap from="~/output/state_array" to="$(var output/state_array)"/>

--- a/v2i_interface/scripts/udp_control.py
+++ b/v2i_interface/scripts/udp_control.py
@@ -51,10 +51,13 @@ class UdpControl:
                 "nanosec": nanosec_time},
             "request_array": request_array}
 
-        self._send_socket.sendto(
-            json.dumps(payload).encode("utf-8"),
-            (self._send_address, self._send_port))
-        self._send_seq_num += 1
+        try:
+            self._send_socket.sendto(
+                json.dumps(payload).encode("utf-8"),
+                (self._send_address, self._send_port))
+            self._send_seq_num += 1
+        except OSError:
+            return -1
 
         return (self._send_seq_num, now_time)
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
v2i_interfaceは、UDP接続が途絶した場合に再接続を試みる設計になっておらず、可用性が低下している問題がある。
本PRでは、UDP接続が途絶してしまっても、IPアドレスを再認識できれば再度接続を確立できる機能を追加する。

具体的には下記の対策を実施する。
- launch.xmlにrespawn=trueおよびrespawn_delay=1.0を設定する。これにより、ノード終了から1.0sec後にノードが再起動する。
- send_toメソッドでOS Errorにはまり動かなくなる挙動が見えているため、send_toメソッドにtry catchを設定して、例外時に意図的にノード終了へ誘導する。これにより再起動を誘発させる。

## Related links

<!-- Write the links related to this PR. -->
[TIERIV INTERNAL LINK](https://tier4.atlassian.net/browse/T4PB-26498)

## Tests performed

<!-- Describe how you have tested this PR. -->
通信途絶後、UDPの再接続ができることを確認しました。
```
#通常接続時
[v2i_interface.py-1] [INFO 1678653743.820247972] [v2i_interface.v2i_interface] send_udp_command(): send udp [{'id': 1, 'request': 1}]
[v2i_interface.py-1] [INFO 1678653743.920380012] [v2i_interface.v2i_interface] send_udp_command(): send udp [{'id': 1, 'request': 1}]
...
#途絶
[v2i_interface.py-1] [ERROR 1678653744.020359240] [v2i_interface.v2i_interface] send_udp_command(): send udp error
[v2i_interface.py-1] Traceback (most recent call last):
[v2i_interface.py-1]   File "/home/autoware/pilot-auto/install/v2i_interface/lib/v2i_interface/v2i_interface.py", line 195, in <module>
[v2i_interface.py-1]     main()
[v2i_interface.py-1]   File "/home/autoware/pilot-auto/install/v2i_interface/lib/v2i_interface/v2i_interface.py", line 191, in main
[v2i_interface.py-1]     rclpy.spin(node)
[v2i_interface.py-1]   File "/opt/ros/galactic/lib/python3.8/site-packages/rclpy/__init__.py", line 196, in spin
[v2i_interface.py-1]     executor.spin_once()
[v2i_interface.py-1]   File "/opt/ros/galactic/lib/python3.8/site-packages/rclpy/executors.py", line 713, in spin_once
[v2i_interface.py-1]     raise handler.exception()
[v2i_interface.py-1]   File "/opt/ros/galactic/lib/python3.8/site-packages/rclpy/task.py", line 239, in __call__
[v2i_interface.py-1]     self._handler.send(None)
[v2i_interface.py-1]   File "/opt/ros/galactic/lib/python3.8/site-packages/rclpy/executors.py", line 418, in handler
[v2i_interface.py-1]     await call_coroutine(entity, arg)
[v2i_interface.py-1]   File "/opt/ros/galactic/lib/python3.8/site-packages/rclpy/executors.py", line 332, in _execute_timer
[v2i_interface.py-1]     await await_or_execute(tmr.callback)
[v2i_interface.py-1]   File "/opt/ros/galactic/lib/python3.8/site-packages/rclpy/executors.py", line 107, in await_or_execute
[v2i_interface.py-1]     return callback(*args)
[v2i_interface.py-1]   File "/home/autoware/pilot-auto/install/v2i_interface/lib/v2i_interface/v2i_interface.py", line 134, in output_timer
[v2i_interface.py-1]     self.publish_infrastructure_states()
[v2i_interface.py-1]   File "/home/autoware/pilot-auto/install/v2i_interface/lib/v2i_interface/v2i_interface.py", line 169, in publish_infrastructure_states
[v2i_interface.py-1]     self._state_array_publisher.publish(vtl_state_array)
[v2i_interface.py-1]   File "/opt/ros/galactic/lib/python3.8/site-packages/rclpy/publisher.py", line 67, in publish
[v2i_interface.py-1]     with self.handle:
[v2i_interface.py-1] rclpy._rclpy_pybind11.InvalidHandle: cannot use Destroyable because destruction was requested
[v2i_interface.py-1] Exception ignored in: <function V2iInterfaceNode.__del__ at 0x7fae7a9c3430>
[v2i_interface.py-1] Traceback (most recent call last):
[v2i_interface.py-1]   File "/home/autoware/pilot-auto/install/v2i_interface/lib/v2i_interface/v2i_interface.py", line 88, in __del__
[v2i_interface.py-1]   File "/home/autoware/pilot-auto/install/v2i_interface/lib/v2i_interface/v2i_interface.py", line 92, in fin
[v2i_interface.py-1] AttributeError: _udp
[ERROR] [v2i_interface.py-1]: process has died [pid 265293, exit code 1, cmd '/home/autoware/pilot-auto/install/v2i_interface/lib/v2i_interface/v2i_interface.py --ros-args -r __node:=v2i_interface -r __ns:=/v2i_interface --params-file /home/autoware/pilot-auto/install/v2i_interface_params/share/v2i_interface_params/config/product/v2i_interface.param.yaml -r ~/input/command_array:=/v2i/infrastructure_commands -r ~/output/state_array:=/v2i/infrastructure_states'].
[INFO] [v2i_interface.py-1]: process started with pid [265619]
[v2i_interface.py-1] [INFO 1678653745.556459700] [v2i_interface.v2i_interface] __init__(): initialized
...
# 再接続できることを確認
[v2i_interface.py-1] [INFO 1678653755.849809648] [v2i_interface.v2i_interface] send_udp_command(): send udp [{'id': 1, 'request': 1}]
[v2i_interface.py-1] [INFO 1678653755.950146598] [v2i_interface.v2i_interface] send_udp_command(): send udp [{'id': 1, 'request': 1}]
```

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/