### PR TITLE
fix(vtl_adapter): remove unnecessary warning

### DIFF
--- a/vtl_adapter/src/self_approval_timer.cpp
+++ b/vtl_adapter/src/self_approval_timer.cpp
@@ -78,8 +78,7 @@ void SelfApprovalTimer::onTimer()
   }
   const auto self_input_state = createState();
   if (!self_input_state) {
-    RCLCPP_WARN_THROTTLE(
-      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+    RCLCPP_DEBUG(node_->get_logger(),
       "SelfApprovalTimer:%s: self input state is not created.", __func__);
     return;
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
vtl_adapterでは、response_type=ANDまたはMATCHの条件で平常時でも下記のようにWarningが出力される（しかも出力され続ける）挙動が確認されている。
この挙動は解析時に有用なWarning情報を埋もれさせることが想定されるため、除去する必要がある。

このPRでは、当該Warningを平常時に表示させないように変更する。
```
[INFO] [launch]: All log files can be found below /home/autoware/.ros/log/2023-03-13-13-57-56-093343-npc2001001-476787
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [vtl_adapter_node-1]: process started with pid [476789]
[vtl_adapter_node-1] [INFO 1678683476.317590591] [vtl_adapter] init(): VtlStateConverter: initialized.
[vtl_adapter_node-1] [INFO 1678683476.318587455] [vtl_adapter] init(): VtlCommandConverter: initialized.
[vtl_adapter_node-1] [INFO 1678683476.318793036] [vtl_adapter] init(): SelfApprovalTimer: initialized.
[vtl_adapter_node-1] [INFO 1678683476.318815180] [vtl_adapter] acceptConverterPipeline(): VtlStateConverter: converter pipeline is accepted.
[vtl_adapter_node-1] [INFO 1678683476.318830890] [vtl_adapter] acceptConverterPipeline(): SelfApprovalTimer: converter pipeline is accepted.
[vtl_adapter_node-1] [WARN 1678683477.193757833] [vtl_adapter] convertADState(): EveVTLInterfaceConverter::convertADState: state is null
```
## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
修正後のログについて、response_type=ANDの平常運用条件で下記の通りWarningが出続ける挙動がなくなっていることを確認した。
（唯一出ているWarningはSIGINTのみであり、これはPR起票者がテスト終了のために介入したものであるため想定内のWarningである）
```
ros2 launch vtl_adapter vtl_adapter.launch.xml 
[INFO] [launch]: All log files can be found below /home/autoware/.ros/log/2023-03-13-14-05-53-774436-npc2001001-480221
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [vtl_adapter_node-1]: process started with pid [480224]
[vtl_adapter_node-1] [INFO 1678683953.988105368] [vtl_adapter] init(): VtlStateConverter: initialized.
[vtl_adapter_node-1] [INFO 1678683953.989040640] [vtl_adapter] init(): VtlCommandConverter: initialized.
[vtl_adapter_node-1] [INFO 1678683953.989247505] [vtl_adapter] init(): SelfApprovalTimer: initialized.
[vtl_adapter_node-1] [INFO 1678683953.989268248] [vtl_adapter] acceptConverterPipeline(): VtlStateConverter: converter pipeline is accepted.
[vtl_adapter_node-1] [INFO 1678683953.989282638] [vtl_adapter] acceptConverterPipeline(): SelfApprovalTimer: converter pipeline is accepted.
^C[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[vtl_adapter_node-1] [INFO 1678683978.325375165] [rclcpp] signal_handler(): signal_handler(signal_value=2)
[INFO] [vtl_adapter_node-1]: process has finished cleanly [pid 480224]

```

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/