### PR TITLE
feat(v2i_command_muxer): add respawn function

### DIFF
--- a/v2i_command_muxer/launch/v2i_command_muxer.launch.xml
+++ b/v2i_command_muxer/launch/v2i_command_muxer.launch.xml
@@ -11,7 +11,8 @@
    limitations under the License.
 -->
 <launch>
-  <node pkg="v2i_command_muxer" exec="v2i_command_muxer_node" name="v2i_command_muxer" output="screen">
+  <node pkg="v2i_command_muxer" exec="v2i_command_muxer_node" name="v2i_command_muxer" output="screen" 
+    respawn="true" respawn_delay="3.0">
     <param from="$(find-pkg-share v2i_command_muxer)/config/topic_definition.yaml"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
v2i_command_muxerは状態を持たず、複数入力を一つにして出力し続けるだけの単純な構造です。
よって、可用性を向上させるのであればrespawnできるようにすることが望ましいです。
本PRでは、同ノードをrespawnできるように変更します。

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
プロセスkillしても再起動することを確認済みです。
```
ros2 launch v2i_command_muxer v2i_command_muxer.launch.xml 
[INFO] [launch]: All log files can be found below /home/autoware/.ros/log/2023-03-13-14-40-20-995937-npc2001001-495740
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [v2i_command_muxer_node-1]: process started with pid [495804]
[ERROR] [v2i_command_muxer_node-1]: process has died [pid 495804, exit code -15, cmd '/home/autoware/pilot-auto/install/v2i_command_muxer/lib/v2i_command_muxer/v2i_command_muxer_node --ros-args -r __node:=v2i_command_muxer --params-file /home/autoware/pilot-auto/install/v2i_command_muxer/share/v2i_command_muxer/config/topic_definition.yaml'].
[INFO] [v2i_command_muxer_node-1]: process started with pid [500236]
```
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/