### PR TITLE
feat(vtl_adapter) : ignore command after passing the end line

### DIFF
--- a/vtl_adapter/src/vtl_command_converter.cpp
+++ b/vtl_adapter/src/vtl_command_converter.cpp
@@ -88,6 +88,8 @@ std::shared_ptr<InterfaceConverterMultiMap> VtlCommandConverter::createConverter
       RCLCPP_DEBUG(node_->get_logger(),
         "VtlCommandConverter:%s: ignore command::NONE.", __func__);
       continue;
+    }else if (orig_elem.state == MainInputCommand::FINALIZED) {
+      continue;
     }
     const auto converter(new InterfaceConverter(orig_elem, node_));
     if (!converter->vtlAttribute()) {

--- a/vtl_adapter/src/vtl_command_converter.cpp
+++ b/vtl_adapter/src/vtl_command_converter.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<InterfaceConverterMultiMap> VtlCommandConverter::createConverter
       RCLCPP_DEBUG(node_->get_logger(),
         "VtlCommandConverter:%s: ignore command::NONE.", __func__);
       continue;
-    }else if (orig_elem.state == MainInputCommand::FINALIZED) {
+    } else if (orig_elem.state == MainInputCommand::FINALIZED) {
       continue;
     }
     const auto converter(new InterfaceConverter(orig_elem, node_));


### PR DESCRIPTION
## PR Type
- Feature

## Description
When the end line is passed (=FINALIZED), stop the command output and ignore the command input.

## Test performed
- Once the VTL state is FINALIZED, stop udp command.

- Once the VTL state is REQUESTING or PASSING, execute udp command.
 *Confirmed the same execution result as [v1.0.2](https://github.com/eve-autonomy/v2i_interface/tree/1.0.2)

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
