### PR TITLE
feat(vtl_adapter) : send blank array after passing the end line

### DIFF
--- a/vtl_adapter/include/vtl_adapter/vtl_adapter.hpp
+++ b/vtl_adapter/include/vtl_adapter/vtl_adapter.hpp
@@ -24,6 +24,7 @@ namespace vtl_adapter
 using VtlCommandConverter = vtl_command_converter::VtlCommandConverter;
 using VtlStateConverter = vtl_state_converter::VtlStateConverter;
 using SelfApprovalTimer = self_approval_timer::SelfApprovalTimer;
+using MainInputCommandArr = tier4_v2x_msgs::msg::InfrastructureCommandArray;
 
 class VtlAdapterNode : public rclcpp::Node
 {
@@ -38,6 +39,11 @@ private:
 
   // self approval timer
   SelfApprovalTimer self_approval_timer_;
+
+  // Subscription
+  rclcpp::Subscription<MainInputCommandArr>::SharedPtr command_sub_;
+
+  void onCommand(const MainInputCommandArr::ConstSharedPtr msg);
 };
 
 }  // namespace vtl_adapter

--- a/vtl_adapter/include/vtl_adapter/vtl_command_converter.hpp
+++ b/vtl_adapter/include/vtl_adapter/vtl_command_converter.hpp
@@ -52,6 +52,7 @@ public:
   VtlCommandConverter();
   void init(rclcpp::Node* node);
   std::shared_ptr<IFConverterDataPipeline> converterPipeline();
+  void onCommand(const MainInputCommandArr::ConstSharedPtr msg);
 private:
   // Node
   rclcpp::Node* node_;
@@ -60,11 +61,9 @@ private:
   rclcpp::Publisher<MainOutputCommandArr>::SharedPtr command_pub_;
 
   // Subscription
-  rclcpp::Subscription<MainInputCommandArr>::SharedPtr command_sub_;
   rclcpp::Subscription<SubInputState>::SharedPtr state_sub_;
 
   // Callback
-  void onCommand(const MainInputCommandArr::ConstSharedPtr msg);
   void onState(const SubInputState::ConstSharedPtr msg);
 
   // Preprocess

--- a/vtl_adapter/include/vtl_adapter/vtl_state_converter.hpp
+++ b/vtl_adapter/include/vtl_adapter/vtl_state_converter.hpp
@@ -62,7 +62,7 @@ private:
   std::optional<OutputStateArr> createState(bool finalize_only);
   std::shared_ptr<IFConverterDataPipeline> converter_pipeline_;
 
-  InputStateArr::ConstSharedPtr state_
+  InputStateArr::ConstSharedPtr state_;
 };
 
 }  // namespace vtl_state_converter

--- a/vtl_adapter/include/vtl_adapter/vtl_state_converter.hpp
+++ b/vtl_adapter/include/vtl_adapter/vtl_state_converter.hpp
@@ -20,6 +20,7 @@
 // input and output
 #include "tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp"
 #include "v2i_interface_msgs/msg/infrastructure_state_array.hpp"
+#include "tier4_v2x_msgs/msg/infrastructure_command_array.hpp"
 
 #include "vtl_adapter/interface_converter_data_pipeline.hpp"
 
@@ -34,6 +35,10 @@ using InterfaceConverterMap =
   std::unordered_map<uint8_t, std::shared_ptr<InterfaceConverter>>;
 using IFConverterDataPipeline =
   interface_converter_data_pipeline::IFConverterDataPipeline;
+using InterfaceConverterMultiMap =
+  std::unordered_multimap<uint8_t, std::shared_ptr<InterfaceConverter>>;
+using MainInputCommandArr = tier4_v2x_msgs::msg::InfrastructureCommandArray;
+using MainInputCommand = tier4_v2x_msgs::msg::InfrastructureCommand;
 
 class VtlStateConverter
 {
@@ -41,6 +46,7 @@ public:
   void init(rclcpp::Node* node);
   bool acceptConverterPipeline(
     std::shared_ptr<IFConverterDataPipeline> converter_pipeline);
+  void onCommand(const MainInputCommandArr::ConstSharedPtr msg);
 private:
   // Node
   rclcpp::Node* node_;
@@ -53,9 +59,11 @@ private:
 
   void onState(const InputStateArr::ConstSharedPtr msg);
 
-  std::optional<OutputStateArr> createState(
-    const InputStateArr::ConstSharedPtr& msg);
+  std::optional<OutputStateArr> createState(bool finalize_only);
   std::shared_ptr<IFConverterDataPipeline> converter_pipeline_;
+  bool isFinalized(const MainInputCommandArr::ConstSharedPtr& original_command);
+
+  InputStateArr::ConstSharedPtr state_
 };
 
 }  // namespace vtl_state_converter

--- a/vtl_adapter/include/vtl_adapter/vtl_state_converter.hpp
+++ b/vtl_adapter/include/vtl_adapter/vtl_state_converter.hpp
@@ -61,7 +61,6 @@ private:
 
   std::optional<OutputStateArr> createState(bool finalize_only);
   std::shared_ptr<IFConverterDataPipeline> converter_pipeline_;
-  bool isFinalized(const MainInputCommandArr::ConstSharedPtr& original_command);
 
   InputStateArr::ConstSharedPtr state_
 };

--- a/vtl_adapter/src/vtl_adapter.cpp
+++ b/vtl_adapter/src/vtl_adapter.cpp
@@ -21,6 +21,8 @@ VtlAdapterNode::VtlAdapterNode(
   const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
 : Node("vtl_adapter", options)
 {
+  using namespace std::placeholders;
+
   state_converter_.init(static_cast<rclcpp::Node*>(this));
   command_converter_.init(static_cast<rclcpp::Node*>(this));
   self_approval_timer_.init(static_cast<rclcpp::Node*>(this));
@@ -28,6 +30,23 @@ VtlAdapterNode::VtlAdapterNode(
     command_converter_.converterPipeline());
   self_approval_timer_.acceptConverterPipeline(
     command_converter_.converterPipeline());
+
+  auto group = create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto subscriber_option = rclcpp::SubscriptionOptions();
+  subscriber_option.callback_group = group;
+
+  // Subscription
+  command_sub_ = create_subscription<MainInputCommandArr>(
+    "~/input/infrastructure_commands", 1,
+    std::bind(&VtlAdapterNode::onCommand, this, _1),
+    subscriber_option);
+}
+
+void VtlAdapterNode::onCommand(const MainInputCommandArr::ConstSharedPtr msg)
+{
+  command_converter_.onCommand(msg);
+  state_converter_.onCommand(msg);
 }
 
 }  // namespace vtl_adapter

--- a/vtl_adapter/src/vtl_command_converter.cpp
+++ b/vtl_adapter/src/vtl_command_converter.cpp
@@ -37,10 +37,6 @@ void VtlCommandConverter::init(rclcpp::Node* node)
   subscriber_option.callback_group = group;
 
   // Subscription
-  command_sub_ = node->create_subscription<MainInputCommandArr>(
-    "~/input/infrastructure_commands", 1,
-    std::bind(&VtlCommandConverter::onCommand, this, _1),
-    subscriber_option);
   state_sub_ = node->create_subscription<SubInputState>(
     "/autoware_state_machine/state", 1,
     std::bind(&VtlCommandConverter::onState, this, _1),

--- a/vtl_adapter/src/vtl_state_converter.cpp
+++ b/vtl_adapter/src/vtl_state_converter.cpp
@@ -87,7 +87,12 @@ void VtlStateConverter::onCommand(const MainInputCommandArr::ConstSharedPtr msg)
   const auto& cmd_arr = msg->commands;
   const auto is_all_commands_finalized =
     (std::count_if(cmd_arr.begin(), cmd_arr.end(), isNotFinalized) == 0);
-  const auto output_state = createState(is_all_commands_finalized);
+  OutputStateArr output_state;
+  if (is_all_commands_finalized) {
+     output_state.stamp = state_->stamp;
+  }else{
+     output_state = createState();
+  }
   if (!output_state) {
     RCLCPP_DEBUG(node_->get_logger(),
       "VtlStateConverter:%s: no valid state is found.", __func__);

--- a/vtl_adapter/src/vtl_state_converter.cpp
+++ b/vtl_adapter/src/vtl_state_converter.cpp
@@ -61,6 +61,12 @@ bool VtlStateConverter::acceptConverterPipeline(
 
 void VtlStateConverter::onState(const InputStateArr::ConstSharedPtr msg)
 {
+  state_ = msg;
+}
+
+void VtlStateConverter::onCommand(const MainInputCommandArr::ConstSharedPtr msg)
+{
+  if (msg->commands.size() > 0){
   if (!converter_pipeline_) {
     RCLCPP_WARN_THROTTLE(
       node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
@@ -73,57 +79,75 @@ void VtlStateConverter::onState(const InputStateArr::ConstSharedPtr msg)
       "VtlStateConverter:%s: converter pipeline is not loaded.", __func__);
     return;
   }
-  const auto output_state = createState(msg);
+  const auto finalize_only = isFinalized(msg);
+  const auto output_state = createState(finalize_only);
   if (!output_state) {
     RCLCPP_DEBUG(node_->get_logger(),
       "VtlStateConverter:%s: no valid state is found.", __func__);
     return;
   }
   state_pub_->publish(output_state.value());
+  }
+}
+
+bool VtlStateConverter::isFinalized(
+    const MainInputCommandArr::ConstSharedPtr& original_command)
+{
+  bool finalized_only = false;
+  for (const auto& orig_elem : original_command->commands) {
+    if (orig_elem.state == MainInputCommand::FINALIZED) {
+      finalized_only = true;
+    }else{
+      return false;
+    }
+  }
+  return finalized_only;
 }
 
 std::optional<OutputStateArr>
-  VtlStateConverter::createState(const InputStateArr::ConstSharedPtr& msg)
+  VtlStateConverter::createState(bool finalized_only)
 {
   const auto converter_multimap = converter_pipeline_->load();
   OutputStateArr output_state_arr;
-  output_state_arr.stamp = msg->stamp;
-  for (const auto& state : msg->states) {
-    if (converter_multimap->count(state.id) < 1) {
+  output_state_arr.stamp = state_->stamp;
+  if (!finalized_only) {
+    for (const auto& state : state_->states) {
+      if (converter_multimap->count(state.id) < 1) {
+        RCLCPP_DEBUG(node_->get_logger(),
+          "VtlStateConverter:%s: no converter is found for id:%d.",
+          __func__, state.id);
+        continue;
+      }
+      auto range = converter_multimap->equal_range(state.id);
+      for (auto it = range.first; it != range.second; ++it) {
+        const auto& converter = it->second;
+        const auto& attr = converter->vtlAttribute();
+        if (!attr) {
+          RCLCPP_DEBUG(node_->get_logger(),
+            "VtlStateConverter:%s: no attribute is found for id:%d.",
+            __func__, state.id);
+          continue;
+        }
+        else if (!attr->isValidAttr()) {
+          RCLCPP_DEBUG(node_->get_logger(),
+            "VtlStateConverter:%s: invalid attribute is found for id:%d.",
+            __func__, state.id);
+          continue;
+        }
+        OutputState output_state;
+        output_state.stamp = state_->stamp;
+        output_state.type = attr->type();
+        output_state.id = converter->command().id;
+        output_state.approval = converter->response(state.state);
+        output_state.is_finalized = true;
+        output_state_arr.states.emplace_back(output_state);
+      }
+    }
+    if (output_state_arr.states.empty()) {
       RCLCPP_DEBUG(node_->get_logger(),
-        "VtlStateConverter:%s: no converter is found for id:%d.",
-        __func__, state.id);
-      continue;
+        "VtlStateConverter:%s: no valid state is found.", __func__);
+      return std::nullopt;
     }
-    auto range = converter_multimap->equal_range(state.id);
-    for (auto it = range.first; it != range.second; ++it) {
-      const auto& converter = it->second;
-      const auto& attr = converter->vtlAttribute();
-      if (!attr) {
-        RCLCPP_DEBUG(node_->get_logger(),
-          "VtlStateConverter:%s: no attribute is found for id:%d.",
-          __func__, state.id);
-        continue;
-      }
-      else if (!attr->isValidAttr()) {
-        RCLCPP_DEBUG(node_->get_logger(),
-          "VtlStateConverter:%s: invalid attribute is found for id:%d.",
-          __func__, state.id);
-        continue;
-      }
-      OutputState output_state;
-      output_state.stamp = msg->stamp;
-      output_state.type = attr->type();
-      output_state.id = converter->command().id;
-      output_state.approval = converter->response(state.state);
-      output_state.is_finalized = true;
-      output_state_arr.states.emplace_back(output_state);
-    }
-  }
-  if (output_state_arr.states.empty()) {
-    RCLCPP_DEBUG(node_->get_logger(),
-      "VtlStateConverter:%s: no valid state is found.", __func__);
-    return std::nullopt;
   }
   return output_state_arr;
 }

--- a/vtl_adapter/src/vtl_state_converter.cpp
+++ b/vtl_adapter/src/vtl_state_converter.cpp
@@ -66,27 +66,29 @@ void VtlStateConverter::onState(const InputStateArr::ConstSharedPtr msg)
 
 void VtlStateConverter::onCommand(const MainInputCommandArr::ConstSharedPtr msg)
 {
-  if (msg->commands.size() > 0){
-  if (!converter_pipeline_) {
-    RCLCPP_WARN_THROTTLE(
-      node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
-      "VtlStateConverter:%s: converter pipeline is not set.", __func__);
+  if (msg->commands.empty()){
     return;
-  }
-  else if (!converter_pipeline_->load()) {
-    RCLCPP_DEBUG(
-      node_->get_logger(),
-      "VtlStateConverter:%s: converter pipeline is not loaded.", __func__);
-    return;
-  }
-  const auto finalize_only = isFinalized(msg);
-  const auto output_state = createState(finalize_only);
-  if (!output_state) {
-    RCLCPP_DEBUG(node_->get_logger(),
-      "VtlStateConverter:%s: no valid state is found.", __func__);
-    return;
-  }
-  state_pub_->publish(output_state.value());
+  }else{
+    if (!converter_pipeline_) {
+      RCLCPP_WARN_THROTTLE(
+        node_->get_logger(), *node_->get_clock(), ERROR_THROTTLE_MSEC,
+        "VtlStateConverter:%s: converter pipeline is not set.", __func__);
+      return;
+    }
+    else if (!converter_pipeline_->load()) {
+      RCLCPP_DEBUG(
+        node_->get_logger(),
+        "VtlStateConverter:%s: converter pipeline is not loaded.", __func__);
+      return;
+    }
+    const auto finalize_only = isFinalized(msg);
+    const auto output_state = createState(finalize_only);
+    if (!output_state) {
+      RCLCPP_DEBUG(node_->get_logger(),
+        "VtlStateConverter:%s: no valid state is found.", __func__);
+      return;
+    }
+    state_pub_->publish(output_state.value());
   }
 }
 

--- a/vtl_adapter/src/vtl_state_converter.cpp
+++ b/vtl_adapter/src/vtl_state_converter.cpp
@@ -87,12 +87,7 @@ void VtlStateConverter::onCommand(const MainInputCommandArr::ConstSharedPtr msg)
   const auto& cmd_arr = msg->commands;
   const auto is_all_commands_finalized =
     (std::count_if(cmd_arr.begin(), cmd_arr.end(), isNotFinalized) == 0);
-  OutputStateArr output_state;
-  if (is_all_commands_finalized) {
-     output_state.stamp = state_->stamp;
-  }else{
-     output_state = createState();
-  }
+  const auto output_state = createState(is_all_commands_finalized);
   if (!output_state) {
     RCLCPP_DEBUG(node_->get_logger(),
       "VtlStateConverter:%s: no valid state is found.", __func__);

--- a/vtl_adapter/src/vtl_state_converter.cpp
+++ b/vtl_adapter/src/vtl_state_converter.cpp
@@ -110,7 +110,9 @@ std::optional<OutputStateArr>
   const auto converter_multimap = converter_pipeline_->load();
   OutputStateArr output_state_arr;
   output_state_arr.stamp = state_->stamp;
-  if (!finalized_only) {
+  if (finalized_only) {
+    return output_state_arr;
+  }else{
     for (const auto& state : state_->states) {
       if (converter_multimap->count(state.id) < 1) {
         RCLCPP_DEBUG(node_->get_logger(),


### PR DESCRIPTION
## PR Type
- Feature

## Description
After passing the end line (=FINALIZED), a blank Array is sent.
- In VtlStateConverter class, add callback for VTL commands topic.
- The actions for the callback.
  - Once the VTL state is FINALIZED, send blank array.
  - Once the VTL state is not FINALIZED, infrastructure states convert v2x states and send.
- The VtlStateConverter and VtlCommandConverter classes use the same subscriber.
  To reduce topic traffic, a single subscriber is spread across two classes.
  - In VtlAdapterNode class, add callback for VTL commands topic.
  - Call the processing of classes that is executed when a VTL command topic is received.
      - VtlStateConverter class.
      - VtlCommandConverter class.

### background
In [v1.0.2](https://github.com/eve-autonomy/v2i_interface/tree/1.0.2), Send an blank infrastructure state to reset the VTL state if no infrastructure state was received.
In [v1.1.0](https://github.com/eve-autonomy/v2i_interface/tree/1.1.0) after, That logic has regressed. 

## Related Links
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/AEAP-545)

## Test performed
- Once the VTL state is FINALIZED, send blank array.
- Once they receive infrastructure states, this states convert v2x states and send.
- If you drive the same VTL twice in a row, both times will stop at the stop line.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
