### PR TITLE
feat(v2i_interface): disable log output send_udp

### DIFF
--- a/v2i_interface/scripts/v2i_interface.py
+++ b/v2i_interface/scripts/v2i_interface.py
@@ -149,7 +149,6 @@ class V2iInterfaceNode(Node):
                 self._logger.error("send udp error")
                 self.fin()
                 return
-            self._logger.info("send udp {0}".format(self._request_array))
 
     def publish_infrastructure_states(self):
         with self.recv_lock:


### PR DESCRIPTION
## Description
In the current system, a large amount of UDP transmission logs in v2i is output, 
making it difficult to read the logs and reducing analysis efficiency.
In order to solve this problem, this PR disables the log that is output when sending UDP.

### Premise
In the current system, when UDP transmission is successful, there is a mechanism to record the UDP transmission success in syslog.
(Analysis is done using syslog only.)
By checking this syslog, the analyst can understand the following.
- If the transmission log remains, at that point, you can see that the process from v2i control input to UDP transmission processing has been consistently successful.
- If the transmission log is interrupted at some point, we know that the UDP transmission has stopped due to some problem in the v2i component.

### Impact
As a demerit of deleting the UDP transmission log, it is assumed that it becomes difficult to determine whether or not the transmission process was successful.
However, since it can be considered as follows, it is considered that there is no problem even if it is erased.
- Determining whether the UDP transmission process is ready or not
  - If the UDP transmission process fails, an error is recorded in syslog separately.
  - There is a respawn mechanism for killing the node itself, and an error is recorded in syslog when it dies or restarts.
  - It is considered that the occurrence frequency of the subscriber or the UDP transmission thread only freezing without killing the node itself is extremely low, so it is possible to determine whether the UDP output was successful or not by analyzing the above two logs.
   
## Tests performed

When v2i_interface test in local, send deta do not  output in system log.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/