### PR TITLE
revert : "chore(v2i_interface) : send udp log output disable (#43)"

### DIFF
--- a/v2i_interface/scripts/v2i_interface.py
+++ b/v2i_interface/scripts/v2i_interface.py
@@ -149,6 +149,7 @@ class V2iInterfaceNode(Node):
                 self._logger.error("send udp error")
                 self.fin()
                 return
+            self._logger.info("send udp {0}".format(self._request_array))
 
     def publish_infrastructure_states(self):
         with self.recv_lock:


### PR DESCRIPTION
# Description
This PR is revert https://github.com/eve-autonomy/v2i_interface/pull/43.
This is done to address [step 1 of issue-45](https://github.com/eve-autonomy/v2i_interface/issues/45#issue-1813034465).
[Only one PR is targeted](https://github.com/eve-autonomy/v2i_interface/compare/1.1.6...1.1.7), so Step.1 of issue-45 is completed with this PR.

# Test performed
Since it is revertPR and it just returns to the existing behavior, there is no need to check the operation.

# Notes for reviewers
Merge https://github.com/eve-autonomy/v2i_interface/pull/43 again in step.4 of [issue-45](https://github.com/eve-autonomy/v2i_interface/issues/45#issue-1813034465).

