### PR TITLE
feat(v2i_interface) : fixed crash when upd communication failed.

### DIFF
--- a/v2i_interface/scripts/v2i_interface.py
+++ b/v2i_interface/scripts/v2i_interface.py
@@ -144,8 +144,7 @@ class V2iInterfaceNode(Node):
             ret = self._udp.send(self._request_array)
             if (ret == -1):
                 self._logger.error("send udp error")
-                self.fin()
-                return
+                raise RuntimeError
 
     def publish_infrastructure_states(self):
         with self.recv_lock:
@@ -182,6 +181,8 @@ def main(args=None):
     except KeyboardInterrupt:
         pass
     except ExternalShutdownException:
+        pass
+    except RuntimeError:
         pass
     finally:
         node.fin()


### PR DESCRIPTION
## Description
There was an issue where the module crashed when UDP communication failed.
This PR is to fix this error.

### How to reproduce
By bringing down the network port of Autoware ECU, communication will be interrupted.
As a result, the `v2i_interface` module crashes.

### error log
```
 [v2i_interface.py-50] [ERROR] [1706062164.976556103] [v2i_interface.v2i_interface]: send udp error
[v2i_interface.py-50] Traceback (most recent call last):
[v2i_interface.py-50]   File "/home/autoware/workspace/autoware_x1/pilot-auto.x1.eve/install/v2i_interface/lib/v2i_interface/v2i_interface.py", line 193, in <module>
[v2i_interface.py-50]     main()
[v2i_interface.py-50]   File "/home/autoware/workspace/autoware_x1/pilot-auto.x1.eve/install/v2i_interface/lib/v2i_interface/v2i_interface.py", line 189, in main
[v2i_interface.py-50]     node.fin()
[v2i_interface.py-50]   File "/home/autoware/workspace/autoware_x1/pilot-auto.x1.eve/install/v2i_interface/lib/v2i_interface/v2i_interface.py", line 89, in fin
[v2i_interface.py-50]     del self._udp
[v2i_interface.py-50] AttributeError: _udp

```

### Cause of error
when UDP communication failed,As the `self.fin()` function is called twice, the same object is deleted twice..
A crash occurs during the second deletion process.
　1. When UDP communication failed in `send_udp_command` function, the `self.fin()` function called.
　2. The `self.fin()` function is called as the finally processing of the `main` function. 

### Error countermeasures
- When UDP communication failed in `send_udp_command` function, raise a runtime error and drop calling the `self.fin()` function.
- the `main` function catch a runtime error.

## Related Links
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/AEAP-761)

## Tests performed
## Function test
  - By disabling the device that performs UPD communication, a UDP communication error occurred.
At this time, confirm that it does not crash.

### before
- In description, error log.

### after
```
[v2i_interface.py-50] [ERROR] [1706059144.792098594] [v2i_interface.v2i_interface]: send udp error
```
 
## Regression test
  - As a result of using the "v2i_interface_test.launch.xml" tool on maps where infrastructure devices exists, it has been confirmed that it is possible to pass through infrastructure devices. 
  - It has been confirmed that it will respawn after the process die.

### console log result
```
[v2i_interface.py-50] [INFO] [1706059144.598223432] [v2i_interface.v2i_interface]: initialized
[v2i_interface.py-50] [ERROR] [1706059144.792098594] [v2i_interface.v2i_interface]: send udp error
[INFO] [v2i_interface.py-50]: process has finished cleanly [pid 36646]
[INFO] [v2i_interface.py-50]: process started with pid [36796]
 ```


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/