### PR TITLE
feat(v2i_interface): add test tool by tkeasygui

### DIFF
--- a/v2i_interface/CMakeLists.txt
+++ b/v2i_interface/CMakeLists.txt
@@ -28,6 +28,7 @@ ament_python_install_package(scripts)
 install(
   PROGRAMS
   scripts/v2i_interface.py
+  scripts/test/v2i_interface_test.py
   DESTINATION
   lib/${PROJECT_NAME})
 

--- a/v2i_interface/README.md
+++ b/v2i_interface/README.md
@@ -45,7 +45,7 @@ pip3 install -r tkeasygui
 ros2 launch v2i_interface v2i_interface_test.launch.xml
 ```
 
-### License
+## License
 This project includes the following third-party software:
 
 - TkEasyGUI Copyright (c) 2024 kujirahand  Licensed under the MIT License.

--- a/v2i_interface/README.md
+++ b/v2i_interface/README.md
@@ -33,3 +33,14 @@ These are mandatory parameters of UDP connection to a user-defined broadcasting 
 |receive_port  |
 
 If you want to use different set of paremeters, fork the [v2i_interface_params.default](https://github.com/eve-autonomy/v2i_interface_params.default) repository.
+
+## How to use test tools
+### install
+Requirements
+```
+pip3 install -r tkeasygui
+```
+### Run 
+```
+ros2 launch v2i_interface v2i_interface_test.launch.xml
+```

--- a/v2i_interface/README.md
+++ b/v2i_interface/README.md
@@ -46,4 +46,7 @@ ros2 launch v2i_interface v2i_interface_test.launch.xml
 ```
 
 ### License
-This Test tool uses tkeasyGUI. tkeasyGUI is distributed under the MIT License. For more details, please see [https://github.com/kujirahand/tkeasygui-python/blob/main/LICENSE].
+This project includes the following third-party software:
+
+- TkEasyGUI Copyright (c) 2024 kujirahand  Licensed under the MIT License.
+For more details, please see [https://github.com/kujirahand/tkeasygui-python/blob/main/LICENSE].

--- a/v2i_interface/README.md
+++ b/v2i_interface/README.md
@@ -44,3 +44,6 @@ pip3 install -r tkeasygui
 ```
 ros2 launch v2i_interface v2i_interface_test.launch.xml
 ```
+
+### License
+This Test tool uses tkeasyGUI. tkeasyGUI is distributed under the MIT License. For more details, please see [https://github.com/kujirahand/tkeasygui-python/blob/main/LICENSE].

--- a/v2i_interface/launch/v2i_interface_test.launch.xml
+++ b/v2i_interface/launch/v2i_interface_test.launch.xml
@@ -19,10 +19,10 @@
 
   <let name="config_dir" value="$(find-pkg-share v2i_interface_params)/config" />
 
-  <!-- <group>
+  <group>
     <push-ros-namespace namespace="v2i_interface"/>
     <node pkg="v2i_interface" exec="v2i_interface_test.py" name="v2i_interface_test" output="screen">
       <param from="$(var config_dir)/$(var operation_mode)/v2i_interface.param.yaml" />
     </node>
-  </group> -->
+  </group>
 </launch>

--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -28,7 +28,6 @@ import os
 
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import QoSDurabilityPolicy, QoSProfile
 
 M_SIZE = 4096
 

--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -74,7 +74,7 @@ class DummyInfraEcu:
 
     def recv(self):
         try:
-            message, cli_addr = self._recv_socket.recvfrom(self._buff_size)
+            message = self._recv_socket.recvfrom(self._buff_size)
         except OSError:
             return -1
 

--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -26,7 +26,6 @@ import TkEasyGUI as eg
 
 import os
 
-import signal
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile

--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+# Copyright 2021 eve autonomy inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from datetime import datetime
+import json
+from socket import AF_INET, IPPROTO_UDP, SOCK_DGRAM, socket
+import threading
+import time
+
+import TkEasyGUI as eg
+
+import os
+
+import signal
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile
+
+M_SIZE = 4096
+
+class DummyInfraEcu:
+    def __init__(self, address, send_port, recv_port, timeout, buff_size):
+
+        self._send_seq_num = 0
+        self._send_address = address
+        self._send_port = send_port
+        self._send_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+
+        self._recv_address = '0.0.0.0'
+        self._recv_port = recv_port
+        self._buff_size = buff_size
+        self._recv_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+        self._recv_socket.bind((self._recv_address, self._recv_port))
+        self._recv_socket.settimeout(timeout)
+
+    def __del__(self):
+        self._send_socket.close()
+        self._recv_socket.close()
+
+    def send(self, id, status, detail, reply_array):
+        now_time = time.time_ns()
+        sec_time = (int)(now_time / 1000 / 1000 / 1000)
+        nanosec_time = now_time - (sec_time * 1000 * 1000 * 1000)
+
+        payload = {
+            "seq_num": self._send_seq_num,
+            "time": {
+                "sec": sec_time,
+                "nanosec": nanosec_time},
+            "id": id,
+            "status": status,
+            "detail": detail,
+            "reply_array": reply_array}
+
+        self._send_socket.sendto(
+            json.dumps(payload).encode("utf-8"),
+            (self._send_address, self._send_port))
+        self._send_seq_num += 1
+
+        return (self._send_seq_num, now_time)
+
+    def recv(self):
+        try:
+            message, cli_addr = self._recv_socket.recvfrom(self._buff_size)
+        except OSError:
+            return -1
+
+        now_time = time.time_ns()
+        data = json.loads(message)
+        recv_seq_num = data["seq_num"]
+        packet_time = (data["time"]["sec"] * 1000 *
+                       1000 * 1000) + data["time"]["nanosec"]
+        request_array = data["request_array"]
+
+        return (recv_seq_num, now_time, packet_time, request_array)
+
+
+class V2iInterfaceTest(Node):
+    def __init__(self):
+        super().__init__('v2i_interface')
+        global window
+
+        # This node sends to v2i_interface/receive_port,
+        #  and receives from v2i_interface/send_port.
+        ip_address = self.declare_parameter("ip_address", "127.0.0.1")
+        send_port = self.declare_parameter("receive_port", 50001)
+        receive_port = self.declare_parameter("send_port", 50000)
+        self._ip_address = ip_address.get_parameter_value().string_value
+        self._send_port = send_port.get_parameter_value().integer_value
+        self._receive_port = receive_port.get_parameter_value().integer_value
+
+        self._th_close = False
+        self._dummy = DummyInfraEcu(
+            self._ip_address,
+            self._send_port,
+            self._receive_port,
+            10.0,
+            M_SIZE)
+
+        output_directory = "/tmp/v2i_interface_test/log/" + \
+            datetime.now().strftime('%Y%m%d_%H%M') + "/"
+        self._recv_output_filename = output_directory + "recv_data.log"
+        self._send_output_filename = output_directory + "send_data.log"
+
+        self._send_count = [[-1, -1, -1], [-1, -1, -1]]
+
+        initial_reply_data = {
+            "id": 0, "time": {"sec": 0, "nanosec": 0},
+            "status": 0, "packet_time": {"sec": 0, "msec": 0},
+            "gpio": 0, "detail": 0,
+            "vehicle": {
+                "id": 0,
+                "request": 0,
+                "delay": 0,
+                "rssi": 0, },
+            "rssi": 0}
+
+        self._reply_array = []
+        self._reply_array.append(initial_reply_data.copy())
+        self._reply_array.append(initial_reply_data.copy())
+        self._reply_array.append(initial_reply_data.copy())
+        self._send_flg = False
+
+        layout = [
+            [eg.Text('Dummy external device')],
+            [
+                eg.Text('ID:'),
+                eg.Input(
+                    '001',
+                    key='-ID0-'),
+                eg.Text('GPIO:'),
+                eg.InputText(
+                    '0',
+                    key='-GPIO0-'),
+                eg.Text('Period(ms):'),
+                eg.Input(
+                    '-1',
+                    key='-PERIOD0-')],
+            [
+                eg.Text('ID:'),
+                eg.Input(
+                    '002',
+                    key='-ID1-'),
+                eg.Text('GPIO:'),
+                eg.Input(
+                    '0',
+                    key='-GPIO1-'),
+                eg.Text('Period(ms):'),
+                eg.Input(
+                    '-1',
+                    key='-PERIOD1-')],
+            [
+                eg.Text('ID:'),
+                eg.Input(
+                    '003',
+                    key='-ID2-'),
+                eg.Text('GPIO:'),
+                eg.Input(
+                    '0',
+                    key='-GPIO2-'),
+                eg.Text('Period(ms):'),
+                eg.Input(
+                    '-1',
+                    key='-PERIOD2-')],
+            [eg.Button('Start ', key='-BUTTON1-', size=(7, 1),),
+             eg.Button('Stop', key='-BUTTON2-', size=(7, 1),)],
+            [eg.Multiline('', key='-OUTPUT-', size=(680, 100))],
+        ]
+
+        window = eg.Window(title='dummy_infrastructure',layout=layout,size=(700, 700),finalize=True)
+        self.run()
+
+    def __del__(self):
+        del self._dummy
+
+    def main_loop(self):
+        self._window_refresh_interval_ms = 100
+        self._base_time = time.time()
+        global send_write
+        while True:
+            if(self._th_close):
+                break
+            data_flg = False
+            reply_array = []
+            if(self._send_flg):
+                for i in range(len(self._send_count[0])):
+                    if(self._send_count[0][i] > 0):
+                        if(self._send_count[1][i] < self._window_refresh_interval_ms):
+                            self._send_count[1][i] = self._send_count[0][i]
+                            reply_array.append(self._reply_array[i])
+                            data_flg = True
+                        else:
+                            self._send_count[1][i] -= self._window_refresh_interval_ms
+            if (data_flg):
+                self._dummy.send(1, 1, 1, reply_array)
+                send_write = True
+                self._fp_send.write('{}, '.format(time.time_ns()))
+                self._fp_send.write(', '.join('{}'.format(x)
+                                              for x in reply_array))
+                self._fp_send.write('\n')
+            window.refresh()
+            next_sleep = (
+                (((self._base_time - time.time()) * 1000) %
+                 self._window_refresh_interval_ms) or self._window_refresh_interval_ms) / 1000
+            time.sleep(next_sleep)
+
+    def recv_from_v2i_interface(self):
+        global recv_write
+        while True:
+            if(self._th_close):
+                break
+
+            ret = self._dummy.recv()
+            if(ret != -1):
+                recv_write = True
+                self._fp_recv.write(', '.join('{}'.format(x) for x in ret))
+                self._fp_recv.write('\n')
+            time.sleep(0.1)
+            pass
+
+    def run(self):
+        global window
+        global send_write
+        global recv_write
+        os.makedirs(os.path.dirname(self._recv_output_filename), exist_ok=True)
+        os.makedirs(os.path.dirname(self._send_output_filename), exist_ok=True)
+
+        self._fp_recv = open(self._recv_output_filename, 'a')
+        th_infra_ecu = threading.Thread(target=self.recv_from_v2i_interface)
+        th_infra_ecu.start()
+
+        self._fp_send = open(self._send_output_filename, 'a')
+        th_main = threading.Thread(target=self.main_loop)
+        th_main.start()
+
+        multilne:eg.Multiline = window['-OUTPUT-']
+        send_write = False
+        recv_write = False
+
+        while True:
+            event, values= window.read(timeout=100)
+            if event is None:
+                break
+            if event == eg.WIN_CLOSED:
+                break
+            if event == '-BUTTON1-':
+                for i in range(len(self._send_count[0])):
+                    self._send_count[0][i] = int(
+                        values["-PERIOD" + str(i) + "-"])
+                    self._send_count[1][i] = int(
+                        values["-PERIOD" + str(i) + "-"])
+                    self._reply_array[i]["id"] = int(
+                        values["-ID" + str(i) + "-"])
+                    self._reply_array[i]["gpio"] = int(
+                        values["-GPIO" + str(i) + "-"], 0)
+                self._send_flg = True
+                window['-BUTTON1-'].update("Change")
+            if event == '-BUTTON2-':
+                self._send_flg = False
+                window['-BUTTON1-'].update("Start ")
+            if send_write == True:
+                multilne.print("send write")
+                send_write = False
+            if recv_write == True:
+                multilne.print("recv write")
+                recv_write = False
+
+        self._th_close = True
+        window.close()
+        th_infra_ecu.join(timeout=0.1)
+        th_main.join(timeout=0.1)
+        self._fp_recv.close()
+        self._fp_send.close()
+
+def main(args=None):
+    global node
+
+    rclpy.init(args=args)
+
+    node = V2iInterfaceTest()
+    node.destroy_node()
+    rclpy.shutdown()
+
+if __name__ == "__main__":
+    main()

--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -189,7 +189,7 @@ class V2iInterfaceTest(Node):
     def main_loop(self):
         self._window_refresh_interval_ms = 100
         self._base_time = time.time()
-        global send_write
+        global is_send_write
         while True:
             if(self._th_close):
                 break
@@ -206,7 +206,7 @@ class V2iInterfaceTest(Node):
                             self._send_count[1][i] -= self._window_refresh_interval_ms
             if (data_flg):
                 self._dummy.send(1, 1, 1, reply_array)
-                send_write = True
+                is_send_write = True
                 self._fp_send.write('{}, '.format(time.time_ns()))
                 self._fp_send.write(', '.join('{}'.format(x)
                                               for x in reply_array))
@@ -233,7 +233,7 @@ class V2iInterfaceTest(Node):
 
     def run(self):
         global window
-        global send_write
+        global is_send_write
         global recv_write
         os.makedirs(os.path.dirname(self._recv_output_filename), exist_ok=True)
         os.makedirs(os.path.dirname(self._send_output_filename), exist_ok=True)
@@ -247,7 +247,7 @@ class V2iInterfaceTest(Node):
         th_main.start()
 
         multilne:eg.Multiline = window['-OUTPUT-']
-        send_write = False
+        is_send_write = False
         recv_write = False
 
         while True:
@@ -271,9 +271,9 @@ class V2iInterfaceTest(Node):
             if event == '-BUTTON2-':
                 self._send_flg = False
                 window['-BUTTON1-'].update("Start ")
-            if send_write == True:
+            if is_send_write == True:
                 multilne.print("send write")
-                send_write = False
+                is_send_write = False
             if recv_write == True:
                 multilne.print("recv write")
                 recv_write = False

--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -240,11 +240,11 @@ class V2iInterfaceTest(Node):
         os.makedirs(os.path.dirname(self._send_output_filename), exist_ok=True)
 
         self._fp_recv = open(self._recv_output_filename, 'a')
-        th_infra_ecu = threading.Thread(target=self.recv_from_v2i_interface)
+        th_infra_ecu = threading.Thread(target=self.recv_from_v2i_interface,daemon=True)
         th_infra_ecu.start()
 
         self._fp_send = open(self._send_output_filename, 'a')
-        th_main = threading.Thread(target=self.main_loop)
+        th_main = threading.Thread(target=self.main_loop,daemon=True)
         th_main.start()
 
         multilne:eg.Multiline = window['-OUTPUT-']

--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -74,7 +74,7 @@ class DummyInfraEcu:
 
     def recv(self):
         try:
-            message, cli_addr = self._recv_socket.recvfrom(self._buff_size)
+            message, _cli_addr = self._recv_socket.recvfrom(self._buff_size)
         except OSError:
             return -1
 

--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -74,7 +74,7 @@ class DummyInfraEcu:
 
     def recv(self):
         try:
-            message = self._recv_socket.recvfrom(self._buff_size)
+            message, cli_addr = self._recv_socket.recvfrom(self._buff_size)
         except OSError:
             return -1
 
@@ -184,6 +184,7 @@ class V2iInterfaceTest(Node):
         self.run()
 
     def __del__(self):
+        self._th_close = True
         del self._dummy
 
     def main_loop(self):

--- a/v2i_interface/scripts/test/v2i_interface_test.py
+++ b/v2i_interface/scripts/test/v2i_interface_test.py
@@ -218,14 +218,14 @@ class V2iInterfaceTest(Node):
             time.sleep(next_sleep)
 
     def recv_from_v2i_interface(self):
-        global recv_write
+        global is_recv_write
         while True:
             if(self._th_close):
                 break
 
             ret = self._dummy.recv()
             if(ret != -1):
-                recv_write = True
+                is_recv_write = True
                 self._fp_recv.write(', '.join('{}'.format(x) for x in ret))
                 self._fp_recv.write('\n')
             time.sleep(0.1)
@@ -234,7 +234,7 @@ class V2iInterfaceTest(Node):
     def run(self):
         global window
         global is_send_write
-        global recv_write
+        global is_recv_write
         os.makedirs(os.path.dirname(self._recv_output_filename), exist_ok=True)
         os.makedirs(os.path.dirname(self._send_output_filename), exist_ok=True)
 
@@ -248,7 +248,7 @@ class V2iInterfaceTest(Node):
 
         multilne:eg.Multiline = window['-OUTPUT-']
         is_send_write = False
-        recv_write = False
+        is_recv_write = False
 
         while True:
             event, values= window.read(timeout=100)
@@ -274,9 +274,9 @@ class V2iInterfaceTest(Node):
             if is_send_write == True:
                 multilne.print("send write")
                 is_send_write = False
-            if recv_write == True:
+            if is_recv_write == True:
                 multilne.print("recv write")
-                recv_write = False
+                is_recv_write = False
 
         self._th_close = True
         window.close()


### PR DESCRIPTION
# Description
#52 でライセンスの都合から、v2i_interfaceのテストツールを削除した。
削除したことによって、停留所設備連携、設備連携VTL機能の設備を含めた挙動確認ができなくなったため、代替となるテストツールを
tkeasyGUIを使って作成する。
合わせて、インストール方法や立ち上げ方のreadme.mdを追加する。

# Related link
https://tier4.atlassian.net/browse/AEAP-1018
# Test

## 妥当性確認
今回新たに利用するtkeasyGUIは[MITライセンス](https://github.com/kujirahand/tkeasygui-python/blob/main/LICENSE)であることが[README](https://github.com/kujirahand/tkeasygui-python/blob/main/README.md)に明記されている。
> This project adopts the lenient MIT license. This license will not change in the future. Let's enjoy creating GUI programs.

よって#52 にて発生していた課金による問題が現時点ないことからtkeasyGUI採用の懸念はないと判断している。


## 機能確認
テストツールの機能確認として、

- v2i_interfaceからUDP通信で送信された情報を受信が正常に動作すること
- 設備を模擬した送信が正常に動作すること

を確認した。
具体的には、v2i_interfaceにUDP通信で車両BXPを模擬した情報を送信して、設備連携機能の評価項目を実施した。

### 送信情報
- 停留所設備連携
- 設備連携VTL
が設定されている環境でPlanning_simulatorを実施し、
で設備機器の情報を送信できていることを確認した。
### 受信情報
v2i_interfaceからUDP通信で送信された情報

## リグレッション確認

テストツールのリグレッション確認として、

- GUI画面が旧ツールの表示と同一となること
- GUIの操作により提供される機能が旧ツールと同一となること

を確認した。

### GUI表示・操作のリグレッション確認
<img src=https://github.com/user-attachments/assets/e2edf72e-dc21-416d-afe3-310ab41ece63 width="300">

- 旧ツールと同一の構成のGUI画面が表示されることを確認した。
- 旧ツール（pysimpleGUI）と同一の操作により、同一の機能が提供されることを確認した。
  - UDP通信で車両BXPを模擬した情報を送信方法が変化ないことを確認済みである。

<details>

<summary>再現手順</summary>

1. tkeasyguiをインストールする
`pip3 install tkeasygui`
2.
`ros2 launch v2i_interface v2i_interface_test.launch.xml`
を実施する

</details>

## remark
今回スコープはライブラリを変更して模擬ツールとして動作できることを対象としているため、
ECUセットアップへの入れ込みは別対応とする。