### PR TITLE
fix: update readme.md

### DIFF
--- a/v2i_interface/README.md
+++ b/v2i_interface/README.md
@@ -38,7 +38,7 @@ If you want to use different set of paremeters, fork the [v2i_interface_params.d
 ### install
 Requirements
 ```
-pip3 install -r TkEasyGUI
+pip3 install TkEasyGUI
 ```
 ### Run 
 ```

--- a/v2i_interface/README.md
+++ b/v2i_interface/README.md
@@ -38,7 +38,7 @@ If you want to use different set of paremeters, fork the [v2i_interface_params.d
 ### install
 Requirements
 ```
-pip3 install -r tkeasygui
+pip3 install -r TkEasyGUI
 ```
 ### Run 
 ```


### PR DESCRIPTION
## Description
v2i_interfaceのテストツールが追加されたが、
installコマンドでエラーが発生してインストールができなかったため、readmeを正しいコマンドに修正する

## Related Link
https://tier4.atlassian.net/browse/AEAP-1018
## Test
`pip3 install  TkEasyGUI`
修正後のコマンドでインストールされていることを確認済み。
```
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: TkEasyGUI in ./.local/lib/python3.10/site-packages (0.2.73)
Requirement already satisfied: pyperclip in ./.local/lib/python3.10/site-packages (from TkEasyGUI) (1.9.0)
Requirement already satisfied: Pillow in ./.local/lib/python3.10/site-packages (from TkEasyGUI) (10.2.0)
```

