### PR TITLE
ci: modify pre-commit setting

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,11 +6,13 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
+
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
 

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,12 +6,11 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out repository
         uses: actions/checkout@v3
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
 


### PR DESCRIPTION
# description
https://github.com/eve-autonomy/v2i_interface/pull/59 のPRで導入されたpre-commitは、PRの送信元がフォーク先のブランチであった場合チェックアウトに失敗してしまうので、PRの送信元ブランチをチェックアウトするように変更する

# test
https://github.com/eve-autonomy/v2i_interface/pull/60/checks
でPRの送信元がフォーク先のブランチであっても正しくチェックアウトできていることを確認。

https://github.com/eve-autonomy/v2i_interface/pull/60/checks
でflake8が期待する動作を行っていることを確認。

