### PR TITLE
fix(cmakelists): add runtime dependencies

### DIFF
--- a/v2i_interface/CMakeLists.txt
+++ b/v2i_interface/CMakeLists.txt
@@ -27,10 +27,8 @@ ament_auto_find_build_dependencies()
 ament_python_install_package(scripts)
 install(
   PROGRAMS
-  scripts/__init__.py
   scripts/v2i_interface.py
   scripts/udp_control.py
-  scripts/test/__init__.py
   scripts/test/v2i_interface_test.py
   DESTINATION
   lib/${PROJECT_NAME})

--- a/v2i_interface/CMakeLists.txt
+++ b/v2i_interface/CMakeLists.txt
@@ -27,7 +27,10 @@ ament_auto_find_build_dependencies()
 ament_python_install_package(scripts)
 install(
   PROGRAMS
+  scripts/__init__.py
   scripts/v2i_interface.py
+  scripts/udp_control.py
+  scripts/test/__init__.py
   scripts/test/v2i_interface_test.py
   DESTINATION
   lib/${PROJECT_NAME})


### PR DESCRIPTION
# Description
従来より、v2i_interface.py実行時の依存関係ファイルがinstallディレクトリ配下へエクスポートされていない問題があった。本PRではこの依存関係のエクスポート設定を追加する。

従来はsymlink install を利用していたことで問題が露見していなかったが、merge install利用により問題が露見するようになった。

# Related Links
https://tier4.atlassian.net/browse/AEAP-3846

# Test Performed
v2i_interface.launch.xml単体起動時にエラーが発生しないことを確認済み。